### PR TITLE
Replace Cell and RefCell usage in display.rs

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -2,7 +2,6 @@ use crate::decor::{Formatted, Repr};
 use crate::document::Document;
 use crate::table::{Item, Table};
 use crate::value::{Array, DateTime, InlineTable, Value};
-use std::cell::{Cell, RefCell};
 use std::fmt::{Display, Formatter, Result};
 
 impl Display for Repr {
@@ -114,10 +113,10 @@ impl Table {
 fn visit_table(
     f: &mut Formatter,
     table: &Table,
-    path: &Vec<&str>,
+    path: &[&str],
     is_array_of_tables: bool,
 ) -> Result {
-    if path.len() == 0 {
+    if path.is_empty() {
         // don't print header for the root node
     } else if is_array_of_tables {
         write!(f, "{}[[", table.decor.prefix)?;


### PR DESCRIPTION
I also split the implementation into a helper method that can walk a tree of tables, and a callback that does the formatting.

Currently, I use a closure to pass the Formatter into the callback, which feels a bit naughty. A cleaner implementation might be to implement the full visitor pattern with a struct, but I get in trouble with lifetimes whenever I store a reference to the Formatter anywhere.

The eventual plan is to create `Table::visit_nested_tables_in_original_order()` and `Document::to_string_in_original_order()` (or similar), to solve https://github.com/killercup/cargo-edit/issues/218 . That PR is still a bit of a mess though, so I've extracted this bit to get the ball rolling.

Tell me what you think.