### PR TITLE
Avoid reordering tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,8 @@ linked-hash-map = "0.5.1"
 combine = "3.5.1"
 
 [dev-dependencies]
-color-backtrace = "0.1.3"
-pretty_assertions = "0.6.1"
 serde_json = "1.0.27"
+pretty_assertions = "0.6.1"
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ linked-hash-map = "0.5.1"
 combine = "3.5.1"
 
 [dev-dependencies]
-serde_json = "1.0.27"
+color-backtrace = "0.1.3"
 pretty_assertions = "0.6.1"
+serde_json = "1.0.27"
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ combine = "3.5.1"
 
 [dev-dependencies]
 serde_json = "1.0.27"
+pretty_assertions = "0.6.1"
 
 [profile.dev]
 opt-level = 1

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ c = { d = "hello" }
 
 ## Limitations
 
-*Things it does not preserve:
+Things it does not preserve:
 * Different quotes and spaces around the same table key, e.g.
 ```toml
 [ 'a'. b]
@@ -56,15 +56,17 @@ will be represented as (spaces are removed, the first encountered quote type is 
 ['a'.c]
 ['a'.d]
 ``` 
-* Children tables before parent table (tables are reordered, see [test]).
-* Scattered array of tables (tables are reordered, see [test]).
+* Children tables before parent table (tables are reordered by default, see [test]).
+* Scattered array of tables (tables are reordered by default, see [test]).
 
 The reason behind the first limitation is that `Table` does not store its header, 
 allowing us to safely swap two tables (we store a mapping in each table: child key -> child table).
 
 This last two limitations allow us to represent a toml document as a tree-like data structure, 
 which enables easier implementation of editing operations 
-and an easy to use and type-safe API.
+and an easy to use and type-safe API. If you care about the above two cases, you
+can use `Document::to_string_in_original_order()` to reconstruct tables in their
+original order.
 
 ## License
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,7 +2,7 @@ use crate::decor::{Formatted, Repr};
 use crate::document::Document;
 use crate::table::{Item, Table};
 use crate::value::{Array, DateTime, InlineTable, Value};
-use std::fmt::{Display, Error, Formatter, Result, Write};
+use std::fmt::{Display, Formatter, Result, Write};
 
 impl Display for Repr {
     fn fmt(&self, f: &mut Formatter) -> Result {
@@ -209,18 +209,20 @@ impl Document {
     /// Document.to_string(). If you have lots of tables that are in strange
     /// orders then it may be significantly slower as it has to walk the tree
     /// multiple times.
-    pub fn to_string_in_original_order(&self) -> std::result::Result<String, Error> {
+    pub fn to_string_in_original_order(&self) -> String {
         let mut string = String::default();
         let mut path = Vec::new();
 
-        self.as_table().visit_nested_tables_in_original_order(
-            &mut path,
-            false,
-            &mut |t, path, is_array| visit_table(&mut string, t, path, is_array),
-        )?;
+        self.as_table()
+            .visit_nested_tables_in_original_order(&mut path, false, &mut |t, path, is_array| {
+                visit_table(&mut string, t, path, is_array)
+            })
+            // write! to string always succeeds, unless we are out of memory,
+            // in which case we can't do much about it.
+            .unwrap();
 
-        write!(string, "{}", self.trailing)?;
-        Ok(string)
+        string.push_str(&self.trailing);
+        string
     }
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -222,6 +222,7 @@ impl Document {
             &mut |t, path, is_array| visit_table(&mut string, t, path, is_array),
         )?;
 
+        write!(string, "{}", self.trailing)?;
         Ok(string)
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -15,7 +15,7 @@ pub struct Document {
 impl Default for Document {
     fn default() -> Self {
         Self {
-            root: Item::Table(Table::default()),
+            root: Item::Table(Table::with_pos(Some(0))),
             trailing: Default::default(),
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -43,6 +43,21 @@ mod tests {
     use crate::parser::*;
     use combine::stream::state::State;
     use combine::*;
+    use pretty_assertions::assert_eq;
+    use std;
+    use std::fmt;
+    // Copied from https://github.com/colin-kiegel/rust-pretty-assertions/issues/24
+    /// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
+    /// Used in different `assert*!` macros in combination with `pretty_assertions` crate to make
+    /// test failures to show nice diffs.
+    #[derive(PartialEq, Eq)]
+    struct PrettyString<'a>(pub &'a str);
+    /// Make diff to display string as multi-line string
+    impl<'a> fmt::Debug for PrettyString<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
 
     macro_rules! parsed_eq {
         ($parsed:ident, $expected:expr) => {{
@@ -461,7 +476,7 @@ that
             assert!(doc.is_ok());
             let doc = doc.unwrap();
 
-            assert_eq!(&doc.to_string(), document);
+            assert_eq!(PrettyString(document), PrettyString(&doc.to_string()));
         }
 
         let invalid_inputs = [r#" hello = 'darkness' # my old friend

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,6 +25,7 @@ use crate::table::Table;
 pub struct TomlParser {
     document: Box<Document>,
     current_table: *mut Table,
+    current_table_position: usize,
 }
 
 impl Default for TomlParser {
@@ -34,6 +35,7 @@ impl Default for TomlParser {
         Self {
             document: doc,
             current_table: table,
+            current_table_position: 0,
         }
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -15,6 +15,9 @@ pub struct Table {
     pub(crate) decor: Decor,
     // whether to hide an empty table
     pub(crate) implicit: bool,
+    // used for putting tables back in their original order when serialising.
+    // Will be None when the Table wasn't parsed from a file.
+    pub(crate) position: Option<usize>,
 }
 
 pub(crate) type KeyValuePairs = LinkedHashMap<InternalString, TableKeyValue>;
@@ -58,12 +61,20 @@ pub type Iter<'a> = Box<dyn Iterator<Item = (&'a str, &'a Item)> + 'a>;
 impl Table {
     /// Creates an empty table.
     pub fn new() -> Self {
-        Self::with_decor(Decor::new("\n", ""))
+        Self::with_decor_and_pos(Decor::new("\n", ""), None)
     }
 
-    pub(crate) fn with_decor(decor: Decor) -> Self {
+    pub(crate) fn with_pos(position: Option<usize>) -> Self {
+        Self {
+            position,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn with_decor_and_pos(decor: Decor, position: Option<usize>) -> Self {
         Self {
             decor,
+            position,
             ..Default::default()
         }
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -386,6 +386,8 @@ impl TableLike for Table {
 /// # Examples
 /// ```rust
 /// # extern crate toml_edit;
+/// # extern crate pretty_assertions;
+/// # use pretty_assertions::assert_eq;
 /// # use toml_edit::*;
 /// # fn main() {
 /// let mut table = Table::default();

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -65,6 +65,13 @@ mod tests {
             assert_eq!(
                 PrettyString(expected),
                 PrettyString(&self.doc.to_string()));
+            self
+        }
+
+        fn produces_sorted(&self, expected: &str) {
+            assert_eq!(
+                PrettyString(expected),
+                PrettyString(&self.doc.to_string_in_original_order().unwrap()));
         }
     }
 
@@ -387,7 +394,17 @@ fn test_sort_values() {
 
         [a.y]
 "#
-    );
+    ).produces_sorted(r#"
+        [a.z]
+
+        [a]
+        a = 1
+        # this comment is attached to b
+        b = 2 # as well as this
+        c = 3
+
+        [a.y]
+"#);
 }
 
 macro_rules! as_array {

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -1,3 +1,4 @@
+extern crate color_backtrace;
 extern crate pretty_assertions;
 extern crate toml_edit;
 
@@ -24,6 +25,9 @@ mod tests {
     use std::iter::FromIterator;
     use std::fmt;
     use pretty_assertions::assert_eq;
+    use std::sync::{Once, ONCE_INIT};
+
+    static INIT_BACKTRACE: Once = ONCE_INIT;
 
     // Copied from https://github.com/colin-kiegel/rust-pretty-assertions/issues/24
     /// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
@@ -43,6 +47,7 @@ mod tests {
     }
 
     fn given(input: &str) -> Test {
+        INIT_BACKTRACE.call_once(color_backtrace::install);
         let doc = input.parse::<Document>();
         assert!(doc.is_ok());
         Test {

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -154,12 +154,8 @@ fn test_inserting_tables_from_different_parsed_docs() {
     ).running(|root| {
         let other = "[b]".parse::<Document>().unwrap();
         root["b"] = other["b"].clone();
-    }).produces_display(
+    }).produces(
         "[a]\n[b]\n"
-    ).produces_in_original_order(
-        // Known limitation of the current approach: b goes missing when
-        // printing.
-        "[a]\n"
     );
 }
 #[test]

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -1,4 +1,3 @@
-extern crate color_backtrace;
 extern crate pretty_assertions;
 extern crate toml_edit;
 
@@ -25,9 +24,6 @@ mod tests {
     use std::iter::FromIterator;
     use std::fmt;
     use pretty_assertions::assert_eq;
-    use std::sync::{Once, ONCE_INIT};
-
-    static INIT_BACKTRACE: Once = ONCE_INIT;
 
     // Copied from https://github.com/colin-kiegel/rust-pretty-assertions/issues/24
     /// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
@@ -47,7 +43,6 @@ mod tests {
     }
 
     fn given(input: &str) -> Test {
-        INIT_BACKTRACE.call_once(color_backtrace::install);
         let doc = input.parse::<Document>();
         assert!(doc.is_ok());
         Test {

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -1,3 +1,4 @@
+extern crate pretty_assertions;
 extern crate toml_edit;
 
 macro_rules! parse_key {
@@ -21,6 +22,21 @@ macro_rules! as_table {
 mod tests {
     use toml_edit::{Document, Key, Value, Table, Item, value, table, array};
     use std::iter::FromIterator;
+    use std::fmt;
+    use pretty_assertions::assert_eq;
+
+    // Copied from https://github.com/colin-kiegel/rust-pretty-assertions/issues/24
+    /// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
+    /// Used in different `assert*!` macros in combination with `pretty_assertions` crate to make
+    /// test failures to show nice diffs.
+    #[derive(PartialEq, Eq)]
+    struct PrettyString<'a>(pub &'a str);
+    /// Make diff to display string as multi-line string
+    impl<'a> fmt::Debug for PrettyString<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
 
     struct Test {
         doc: Document,
@@ -45,8 +61,10 @@ mod tests {
             self
         }
 
-        fn produces(&self, expected: &str) {
-            assert_eq!(self.doc.to_string(), expected);
+        fn produces(&self, expected: &str) -> &Self {
+            assert_eq!(
+                PrettyString(expected),
+                PrettyString(&self.doc.to_string()));
         }
     }
 

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -71,7 +71,7 @@ mod tests {
         fn produces_in_original_order(&self, expected: &str) -> &Self {
             assert_eq!(
                 PrettyString(expected),
-                PrettyString(&self.doc.to_string_in_original_order().unwrap()));
+                PrettyString(&self.doc.to_string_in_original_order()));
             self
         }
 

--- a/tests/test_valid.rs
+++ b/tests/test_valid.rs
@@ -94,6 +94,16 @@ fn table_reordering() {
 [a."b".c]
 [[bin]] # bin 3
 "#;
+    let expected_original_order = r#"
+[[bin]] # bin 1
+[a.'b'.c.e]
+[a]
+[other.table]
+[[bin]] # bin 2
+[a.'b'.c.d]
+[a.'b'.c]
+[[bin]] # bin 3
+"#;
     let expected = r#"
 [[bin]] # bin 1
 [[bin]] # bin 2
@@ -107,6 +117,11 @@ fn table_reordering() {
     let doc = toml.parse::<Document>();
     assert!(doc.is_ok());
     let doc = doc.unwrap();
+
+    assert_eq!(
+        doc.to_string_in_original_order().unwrap(),
+        expected_original_order
+    );
     assert_eq!(doc.to_string(), expected);
 }
 

--- a/tests/test_valid.rs
+++ b/tests/test_valid.rs
@@ -109,7 +109,7 @@ fn test_table_reordering() {
     let doc = doc.unwrap();
 
     assert_eq!(doc.to_string(), expected);
-    assert_eq!(doc.to_string_in_original_order().unwrap(), toml);
+    assert_eq!(doc.to_string_in_original_order(), toml);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn test_key_unification() {
     let doc = doc.unwrap();
 
     assert_eq!(doc.to_string(), expected);
-    assert_eq!(doc.to_string_in_original_order().unwrap(), expected);
+    assert_eq!(doc.to_string_in_original_order(), expected);
 }
 
 t!(

--- a/tests/test_valid.rs
+++ b/tests/test_valid.rs
@@ -83,25 +83,15 @@ macro_rules! t(
 );
 
 #[test]
-fn table_reordering() {
+fn test_table_reordering() {
     let toml = r#"
 [[bin]] # bin 1
-[a.'b'.c.e]
+[a.b.c.e]
 [a]
 [other.table]
 [[bin]] # bin 2
 [a.b.c.d]
-[a."b".c]
-[[bin]] # bin 3
-"#;
-    let expected_original_order = r#"
-[[bin]] # bin 1
-[a.'b'.c.e]
-[a]
-[other.table]
-[[bin]] # bin 2
-[a.'b'.c.d]
-[a.'b'.c]
+[a.b.c]
 [[bin]] # bin 3
 "#;
     let expected = r#"
@@ -109,20 +99,39 @@ fn table_reordering() {
 [[bin]] # bin 2
 [[bin]] # bin 3
 [a]
-[a.'b'.c]
-[a.'b'.c.e]
-[a.'b'.c.d]
+[a.b.c]
+[a.b.c.e]
+[a.b.c.d]
 [other.table]
 "#;
     let doc = toml.parse::<Document>();
     assert!(doc.is_ok());
     let doc = doc.unwrap();
 
-    assert_eq!(
-        doc.to_string_in_original_order().unwrap(),
-        expected_original_order
-    );
     assert_eq!(doc.to_string(), expected);
+    assert_eq!(doc.to_string_in_original_order().unwrap(), toml);
+}
+
+#[test]
+fn test_key_unification() {
+    let toml = r#"
+[a]
+[a.'b'.c]
+[a."b".c.e]
+[a.b.c.d]
+"#;
+    let expected = r#"
+[a]
+[a.'b'.c]
+[a.'b'.c.e]
+[a.'b'.c.d]
+"#;
+    let doc = toml.parse::<Document>();
+    assert!(doc.is_ok());
+    let doc = doc.unwrap();
+
+    assert_eq!(doc.to_string(), expected);
+    assert_eq!(doc.to_string_in_original_order().unwrap(), expected);
 }
 
 t!(

--- a/tests/test_valid.rs
+++ b/tests/test_valid.rs
@@ -1,6 +1,8 @@
+extern crate pretty_assertions;
 extern crate serde_json;
 extern crate toml_edit;
 
+use pretty_assertions::assert_eq;
 use serde_json::Map as JsonMap;
 use serde_json::Value as Json;
 


### PR DESCRIPTION
Adds Document::to_string_in_original_order()

This is intended to help with https://github.com/killercup/cargo-edit/issues/218
    
We save .position = Some(i) on each Table, starting with i = 0 for
the root of the Document, and then incrementing each time we see a
table header.

When serialising, ~we start looking for a Table with position 0,
which we should find at the root of the document. We then continue
scanning, looking for position 1 and so on. If the document doesn't
need re-ordering then we will on need to do a single scan.~ we start by 
doing a walk over the tree and working out which positions exist
(storing them in a Vec and then sorting them). We then do subsequent
walks to find each of the known positions in turn. Each walk of the tree
is guaranteed to yield at least one table, but will probably yield more.
If the document doesn't need re-ordering then we will on need to do a single scan.

If a Table has been added using the API rather than parsed then it
will have position = None. We only want to serialise each Table
once, so we only print tables with position = None if the table
we visited immediately before it had the right position.

If we didn't manage to serialise all Tables after a single loop
then we keep looping until we are done. ~There is code to make sure
we don't get stuck when someone causes a gap in the numbers by
deleting a Table.~ It is impossible for the loop to get stuck, because
it only searches for position values that it already knows are in the tree.

Known issues:
- [x] ~If you have created your Document by parsing two .toml files and
  merging the results together, this method may silently skip some
  tables. Please use Document.to_string() instead, which doesn't have
  this problem.~ fixed
- [ ] The best case performance of this function is a bit worse than
  Document.to_string(). It will be significantly worse if you have lots of
  tables that are in strange orders.


Also adds `pretty_assertions` in some tests and color-backtrace (as separate commits) because I found debugging test failures more tricky without them.

Things to do before merging:
- [x] make a version of cargo-edit which uses this patch, and make sure that it actually works on my test samples at https://github.com/alsuren/rust-repos/tree/cargo.toml-samples
  - see https://github.com/killercup/cargo-edit/pull/312
  - went from 1457 funky files down to 13 (and I think that some of them are because I didn't clean up the unix/windows line endings correctly)
- [x] Write a few more integration tests, describing interesting edge cases from the repo. For example:
  - [x] An example with trailing comments after the end of the document.
  - [x] An example where `[package.metadata.deb]` is at the bottom of the file and it stays there.
    * The table_reordering test already does this.
  - [x] A test with the following document, where you add `[dependencies.somethingelse]` and it is added after `[dependencies.opencl]` rather than before `[[example]]`.
```
[package]
[dependencies]
[[example]]
[dependencies.opencl]
[dev-dependencies]
```
- [x] Is the API okay? Display.to_string() seems to swallow the error case (possibly by panicking). Should we do the same? (answer: yes)
- [x] (edit: added a commit to use this new algorithm) Is it enough to document the issue where it can silently skip tables that are parsed from multiple files, or should I check for it? If I want to fix it properly then the best way to do it is to:
  * walk the tree once, gathering all of the known `position` numbers unto a vec
  * Sort the positions vec
  * Walk the tree and pop off items from the positions vec as I go (rather than incrementing an integer)
  * Stop looping when the vec is empty.
  * This is probably simpler than my current implementation, but forces me to allocate another vec, and then do at least two passes of the tree, even if the tables are in the correct order already.
- [x] update the limitations section of the readme to explain that you should use Document::to_string_in_original_order() if you care about not forcing nested tables to be grouped next to their parents.
  - [ ] Once this PR is merged, make another PR to point `https://github.com/ordian/toml_edit/blob/f09bd5d075fdb7d2ef8d9bb3270a34506c276753/tests/test_valid.rs#L84` at the updated test.