### PR TITLE
Update combine dependency to 4.5.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.10"
 linked-hash-map = "0.5.2"
-combine = "3.8.1"
+combine = "4.5.2"
 
 [dev-dependencies]
 serde_json = "1.0.44"

--- a/src/formatted.rs
+++ b/src/formatted.rs
@@ -4,7 +4,7 @@ use crate::parser::strings;
 use crate::parser::TomlError;
 use crate::table::{Item, KeyValuePairs, TableKeyValue};
 use crate::value::{Array, DateTime, InlineTable, Value};
-use combine::stream::state::State;
+use combine::stream::position::Stream as PositionStream;
 use std::iter::FromIterator;
 
 pub(crate) fn decorate_array(array: &mut Array) {
@@ -137,8 +137,8 @@ impl From<f64> for Value {
 
 macro_rules! try_parse {
     ($s:expr, $p:expr) => {{
-        use combine::Parser;
-        let result = $p.easy_parse(State::new($s));
+        use combine::EasyParser;
+        let result = $p.easy_parse(PositionStream::new($s));
         match result {
             Ok((_, ref rest)) if !rest.input.is_empty() => {
                 Err(TomlError::from_unparsed(rest.positioner, $s))

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,6 @@
 use crate::decor::InternalString;
 use crate::parser;
-use combine::stream::state::State;
+use combine::stream::position::Stream;
 use std::str::FromStr;
 
 /// Key as part of a Key/Value Pair or a table header.
@@ -48,8 +48,8 @@ impl FromStr for Key {
 
 impl Key {
     fn try_parse(s: &str) -> Result<Key, parser::TomlError> {
-        use combine::Parser;
-        let result = parser::key_parser().easy_parse(State::new(s));
+        use combine::EasyParser;
+        let result = parser::key_parser().easy_parse(Stream::new(s));
         match result {
             Ok((_, ref rest)) if !rest.input.is_empty() => {
                 Err(parser::TomlError::from_unparsed(rest.positioner, s))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(missing_docs)]
-// #![deny(warnings)]
 // https://github.com/Marwes/combine/issues/172
 #![recursion_limit = "256"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![deny(warnings)]
+// #![deny(warnings)]
 // https://github.com/Marwes/combine/issues/172
 #![recursion_limit = "256"]
 

--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -4,8 +4,8 @@ use crate::parser::errors::CustomError;
 use crate::parser::trivia::ws_comment_newline;
 use crate::parser::value::value;
 use crate::value::{Array, Value};
-use combine::char::char;
-use combine::range::recognize_with_value;
+use combine::parser::char::char;
+use combine::parser::range::recognize_with_value;
 use combine::stream::RangeStream;
 use combine::*;
 

--- a/src/parser/datetime.rs
+++ b/src/parser/datetime.rs
@@ -1,12 +1,12 @@
 use crate::value;
-use combine::char::{char, digit};
-use combine::combinator::{skip_count_min_max, SkipCountMinMax};
-use combine::range::{recognize, recognize_with_value};
+use combine::parser::char::{char, digit};
+use combine::parser::range::{recognize, recognize_with_value};
+use combine::parser::repeat::{skip_count_min_max, SkipCountMinMax};
 use combine::stream::RangeStream;
 use combine::*;
 
 #[inline]
-pub fn repeat<P: Parser>(count: usize, parser: P) -> SkipCountMinMax<P> {
+pub fn repeat<I: Stream, P: Parser<I>>(count: usize, parser: P) -> SkipCountMinMax<I, P> {
     skip_count_min_max(count, count, parser)
 }
 

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -1,6 +1,6 @@
 use combine::easy::Errors as ParseError;
 use combine::stream::easy::Error;
-use combine::stream::state::SourcePosition;
+use combine::stream::position::SourcePosition;
 use std::error::Error as StdError;
 use std::fmt::{Display, Formatter, Result};
 
@@ -118,7 +118,9 @@ impl Display for CustomError {
             CustomError::MixedArrayType {
                 ref got,
                 ref expected,
-            } => writeln!(f, "Mixed types in array: {} and {}", expected, got),
+            } => {
+                writeln!(f, "Mixed types in array: {} and {}", expected, got)
+            }
             CustomError::DuplicateKey { ref key, ref table } => {
                 writeln!(f, "Duplicate key `{}` in `{}` table", key, table)
             }

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -6,7 +6,7 @@ use crate::parser::trivia::ws;
 use crate::parser::value::value;
 use crate::table::{Item, TableKeyValue};
 use crate::value::InlineTable;
-use combine::char::char;
+use combine::parser::char::char;
 use combine::stream::RangeStream;
 use combine::*;
 

--- a/src/parser/key.rs
+++ b/src/parser/key.rs
@@ -1,6 +1,6 @@
 use crate::decor::InternalString;
 use crate::parser::strings::{basic_string, literal_string};
-use combine::range::{recognize_with_value, take_while1};
+use combine::parser::range::{recognize_with_value, take_while1};
 use combine::stream::RangeStream;
 use combine::*;
 

--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -7,7 +7,7 @@ macro_rules! parse (
                 where
                 [I: RangeStream<
                  Range = &'a str,
-                 Item = char>,
+                 Token = char>,
                  I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
                  <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
                  From<std::num::ParseIntError> +
@@ -31,7 +31,7 @@ macro_rules! toml_parser (
             where
                 [I: RangeStream<
                  Range = &'a str,
-                 Item = char>,
+                 Token = char>,
                  I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
                  <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
                  From<std::num::ParseIntError> +

--- a/src/parser/numbers.rs
+++ b/src/parser/numbers.rs
@@ -1,5 +1,5 @@
-use combine::char::{char, digit, hex_digit, oct_digit, string};
-use combine::range::{range, recognize};
+use combine::parser::char::{char, digit, hex_digit, oct_digit, string};
+use combine::parser::range::{range, recognize};
 use combine::stream::RangeStream;
 use combine::*;
 

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -6,8 +6,8 @@ use crate::parser::key::key;
 use crate::parser::trivia::{line_trailing, ws};
 use crate::parser::TomlParser;
 use crate::table::{Item, Table};
-use combine::char::char;
-use combine::range::range;
+use combine::parser::char::char;
+use combine::parser::range::range;
 use combine::stream::RangeStream;
 use combine::*;
 use std::cell::RefCell;
@@ -68,7 +68,7 @@ parser! {
     where
         [I: RangeStream<
          Range = &'a str,
-         Item = char>,
+         Token = char>,
          I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
          <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
          From<std::num::ParseIntError> +

--- a/src/parser/trivia.rs
+++ b/src/parser/trivia.rs
@@ -1,5 +1,5 @@
-use combine::char::{char, crlf, newline as lf};
-use combine::range::{recognize, take_while, take_while1};
+use combine::parser::char::{char, crlf, newline as lf};
+use combine::parser::range::{recognize, take_while, take_while1};
 use combine::stream::RangeStream;
 use combine::*;
 

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -6,7 +6,7 @@ use crate::parser::inline_table::inline_table;
 use crate::parser::numbers::{boolean, float, integer};
 use crate::parser::strings::string;
 use crate::value as v;
-use combine::range::recognize_with_value;
+use combine::parser::range::recognize_with_value;
 use combine::stream::RangeStream;
 use combine::*;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -4,7 +4,7 @@ use crate::parser;
 use crate::table::{Item, Iter, KeyValuePairs, TableKeyValue, TableLike};
 use crate::{decorated, formatted};
 use chrono::{self, FixedOffset};
-use combine::stream::state::State;
+use combine::stream::position::Stream;
 use linked_hash_map::LinkedHashMap;
 use std::mem;
 use std::str::FromStr;
@@ -519,8 +519,8 @@ impl FromStr for Value {
 
     /// Parses a value from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use combine::Parser;
-        let parsed = parser::value_parser().easy_parse(State::new(s));
+        use combine::EasyParser;
+        let parsed = parser::value_parser().easy_parse(Stream::new(s));
         match parsed {
             Ok((_, ref rest)) if !rest.input.is_empty() => {
                 Err(Self::Err::from_unparsed(rest.positioner, s))


### PR DESCRIPTION
Closes #96.

This update means that a vulnerable version of the `ascii` crate is no longer required to build. It also resolves several unsafe code issues in the combine crate.