### PR TITLE
release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.2.1] - 2021-06-07
+- Added `Table::decor`. [#97](https://github.com/ordian/toml_edit/pull/97)
+- Added `IterMut` for `Table`. [#100](https://github.com/ordian/toml_edit/pull/100)
+- Added `Table::get_mut`. [#106](https://github.com/ordian/toml_edit/pull/106)
+- Updated `combine` to 4.5. [#107](https://github.com/ordian/toml_edit/pull/107)
+
 ## [0.2.0] - 2020-06-18
 - Added format preserving mutation functions for `Array`. [#88](https://github.com/ordian/toml_edit/pull/88)
 ### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toml_edit"
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 keywords = ["toml"]


### PR DESCRIPTION
Fixes #108.

@anp thanks for the reminder, I think the changes listed here are semver non-breaking https://doc.rust-lang.org/cargo/reference/semver.html#semver-compatibility modulo MSRV bump maybe.