### PR TITLE
fix(grammar): Reject 0x7F according to 1.0 spec

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -80,8 +80,12 @@ mod tests {
     macro_rules! parsed_value_eq {
         ($input:expr) => {
             let parsed = value::value().easy_parse(Stream::new(*$input));
-            assert!(parsed.is_ok());
-            let (v, rest) = parsed.unwrap();
+            let (v, rest) = match parsed {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    panic!("Unexpected error for {:?}: {}", $input, err);
+                }
+            };
             assert_eq!(v.to_string(), *$input);
             assert!(rest.input.is_empty());
         };
@@ -411,7 +415,7 @@ trimmed in raw strings.
    is preserved.
 '''"#,
             r#""Jos\u00E9\n""#,
-            r#""\\\"\b\/\f\n\r\t\u00E9\U000A0000""#,
+            r#""\\\"\b/\f\n\r\t\u00E9\U000A0000""#,
             r#"{ hello = "world", a = 1}"#,
             r#"[ { x = 1, a = "2" }, {a = "a",b = "b",     c =    "c"} ]"#,
         ];

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -100,7 +100,7 @@ fn is_mlb_unescaped(c: char) -> bool {
     is_wschar(c)
         | matches!(c, '\u{21}' | '\u{23}'..='\u{5B}' | '\u{5D}'..='\u{7E}')
         | is_non_ascii(c)
-        // Unlike he official grammar, we can handle quotes just fine
+        // Unlike the official grammar, we can handle quotes just fine
         | (c == '\u{22}')
 }
 
@@ -186,7 +186,7 @@ const ML_LITERAL_STRING_DELIM: &str = "'''";
 #[inline]
 fn is_mll_char(c: char) -> bool {
     matches!(c, '\u{09}' | '\u{20}'..='\u{26}' | '\u{28}'..='\u{7E}') | is_non_ascii(c)
-        // Unlike he official grammar, we can handle quotes just fine
+        // Unlike the official grammar, we can handle quotes just fine
         | (c == '\u{27}')
 }
 

--- a/src/parser/trivia.rs
+++ b/src/parser/trivia.rs
@@ -6,7 +6,7 @@ use combine::*;
 // wschar = ( %x20 /              ; Space
 //            %x09 )              ; Horizontal tab
 #[inline]
-fn is_wschar(c: char) -> bool {
+pub fn is_wschar(c: char) -> bool {
     matches!(c, ' ' | '\t')
 }
 
@@ -15,10 +15,16 @@ parse!(ws() -> &'a str, {
     take_while(is_wschar)
 });
 
-// non-eol = %x09 / %x20-10FFFF
+// non-ascii = %x80-D7FF / %xE000-10FFFF
+#[inline]
+pub fn is_non_ascii(c: char) -> bool {
+    matches!(c, '\u{80}'..='\u{D7FF}' | '\u{E000}'..='\u{10FFFF}')
+}
+
+// non-eol = %x09 / %x20-7E / non-ascii
 #[inline]
 fn is_non_eol(c: char) -> bool {
-    matches!(c, '\u{09}' | '\u{20}'..='\u{10FFFF}')
+    matches!(c, '\u{09}' | '\u{20}'..='\u{7E}') | is_non_ascii(c)
 }
 
 // comment-start-symbol = %x23 ; #

--- a/tests/decoder_compliance.rs
+++ b/tests/decoder_compliance.rs
@@ -3,12 +3,6 @@ fn main() {
     let mut harness = toml_test_harness::DecoderHarness::new(decoder);
     harness
         .ignore([
-            "invalid/control/comment-del.toml",
-            "invalid/control/multi-del.toml",
-            "invalid/control/rawmulti-del.toml",
-            "invalid/control/rawstring-del.toml",
-            "invalid/control/string-del.toml",
-            "invalid/string/bad-slash-escape.toml",
             "valid/array/array.toml",
             "valid/array/mixed-int-array.toml",
             "valid/array/mixed-int-float.toml",

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -44,8 +44,8 @@ fn test_key_from_str() {
     test_key!("a", "a");
     test_key!(r#"'hello key'"#, "hello key");
     test_key!(
-        r#""Jos\u00E9\U000A0000\n\t\r\f\b\\\/\"""#,
-        "Jos\u{00E9}\u{A0000}\n\t\r\u{c}\u{8}\\/\""
+        r#""Jos\u00E9\U000A0000\n\t\r\f\b\"""#,
+        "Jos\u{00E9}\u{A0000}\n\t\r\u{c}\u{8}\""
     );
     test_key!("", "");
     test_key!("'hello key'bla", "'hello key'bla");
@@ -85,6 +85,6 @@ string'''"#
     let wp = "C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\cargo-edit-test.YizxPxxElXn9";
     let lwp = "'C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\cargo-edit-test.YizxPxxElXn9'";
     assert_eq!(Value::from(wp).as_str(), parse_value!(lwp).as_str());
-    let basic = r#""\\\"\b\/\f\n\r\t\u00E9\U000A0000""#;
+    let basic = r#""\\\"\b\f\n\r\t\u00E9\U000A0000""#;
     assert_eq!(Value::from(basic).as_str(), parse_value!(basic).as_str());
 }


### PR DESCRIPTION
As of this commit, the ABNF and spec conflict on handling of comments.
This errs in favor of the spec / `toml-test` / consistency.

In fixing this, we somehow broke individual quotes in strings.  The
grammar has special consideration for those, so deferring that to
another commit.