### PR TITLE
fix!: Allow mixed-type arrays

### DIFF
--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -24,13 +24,7 @@ fn array_from_vec(v: Vec<Value>, comma: bool, trailing: &str) -> Result<Array, C
         ..Default::default()
     };
     for val in v {
-        let err = Err(CustomError::MixedArrayType {
-            got: format!("{:?}", val.get_type()),
-            expected: format!("{:?}", array.value_type()),
-        });
-        if array.push_formatted(val).is_err() {
-            return err;
-        }
+        array.push_formatted(val)
     }
     Ok(array)
 }

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -100,7 +100,6 @@ impl<'a> Display for FancyError<'a> {
 
 #[derive(Debug, Clone)]
 pub enum CustomError {
-    MixedArrayType { got: String, expected: String },
     DuplicateKey { key: String, table: String },
     InvalidHexEscape(u32),
     UnparsedLine,
@@ -115,12 +114,6 @@ impl StdError for CustomError {
 impl Display for CustomError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match *self {
-            CustomError::MixedArrayType {
-                ref got,
-                ref expected,
-            } => {
-                writeln!(f, "Mixed types in array: {} and {}", expected, got)
-            }
             CustomError::DuplicateKey { ref key, ref table } => {
                 writeln!(f, "Duplicate key `{}` in `{}` table", key, table)
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -358,7 +358,7 @@ trimmed in raw strings.
             parsed_value_eq!(input);
         }
 
-        let invalid_inputs = [r#"["#, r#"[,]"#, r#"[,2]"#, r#"[1e165,,]"#, r#"[ 1, 2.0 ]"#];
+        let invalid_inputs = [r#"["#, r#"[,]"#, r#"[,2]"#, r#"[1e165,,]"#];
         for input in &invalid_inputs {
             let parsed = array::array().easy_parse(Stream::new(*input));
             assert!(parsed.is_err());

--- a/tests/decoder_compliance.rs
+++ b/tests/decoder_compliance.rs
@@ -4,11 +4,6 @@ fn main() {
     harness
         .ignore([
             "valid/array/array.toml",
-            "valid/array/mixed-int-array.toml",
-            "valid/array/mixed-int-float.toml",
-            "valid/array/mixed-int-string.toml",
-            "valid/array/mixed-string-table.toml",
-            "valid/array/nested-double.toml",
             "valid/comment/everywhere.toml",
             "valid/datetime/datetime.toml",
             "valid/datetime/local-date.toml",

--- a/tests/fixtures/invalid/array-mixed-types-arrays-and-ints.toml
+++ b/tests/fixtures/invalid/array-mixed-types-arrays-and-ints.toml
@@ -1,1 +1,0 @@
-arrays-and-ints =  [1, ["Arrays are not integers."]]

--- a/tests/fixtures/invalid/array-mixed-types-ints-and-floats.toml
+++ b/tests/fixtures/invalid/array-mixed-types-ints-and-floats.toml
@@ -1,1 +1,0 @@
-ints-and-floats = [1, 1.1]

--- a/tests/fixtures/invalid/array-mixed-types-strings-and-ints.toml
+++ b/tests/fixtures/invalid/array-mixed-types-strings-and-ints.toml
@@ -1,1 +1,0 @@
-strings-and-ints = ["hi", 42]

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -538,29 +538,26 @@ fn test_insert_replace_into_array() {
             let a = as_array!(a);
             assert_eq!(a.len(), 3);
             assert!(a.get(2).is_some());
-            assert!(a.push(4).is_ok());
+            a.push(4);
             assert_eq!(a.len(), 4);
             a.fmt();
         }
         let b = root.entry("b");
         let b = as_array!(b);
         assert!(b.is_empty());
-        assert!(b.push("hello").is_ok());
+        b.push("hello");
         assert_eq!(b.len(), 1);
 
-        assert!(b.push_formatted(decorated("world".into(), "\n", "\n")).is_ok());
-        assert!(b.push_formatted(decorated("test".into(), "", "")).is_ok());
+        b.push_formatted(decorated("world".into(), "\n", "\n"));
+        b.push_formatted(decorated("test".into(), "", ""));
 
-        assert!(b.insert(1, "beep").is_ok());
-        assert!(b.insert_formatted(2, decorated("boop".into(), "   ", "   ")).is_ok());
+        b.insert(1, "beep");
+        b.insert_formatted(2, decorated("boop".into(), "   ", "   "));
 
         // This should preserve formatting.
-        assert_eq!(b.replace(2, "zoink").unwrap().as_str(), Some("boop"));
+        assert_eq!(b.replace(2, "zoink").as_str(), Some("boop"));
         // This should replace formatting.
-        assert_eq!(b.replace_formatted(4, decorated("yikes".into(), "  ", "")).unwrap().as_str(), Some("test"));
-
-        // Check that pushing a different type into an array fails.
-        assert!(b.push(42).is_err());
+        assert_eq!(b.replace_formatted(4, decorated("yikes".into(), "  ", "")).as_str(), Some("test"));
 
     }).produces(r#"
         a = [1, 2, 3, 4]

--- a/tests/test_invalid.rs
+++ b/tests/test_invalid.rs
@@ -21,21 +21,6 @@ macro_rules! t(
 );
 
 t!(
-    test_array_mixed_types_arrays_and_ints,
-    "Mixed types in array",
-    "fixtures/invalid/array-mixed-types-arrays-and-ints.toml"
-);
-t!(
-    test_array_mixed_types_ints_and_floats,
-    "Mixed types in array",
-    "fixtures/invalid/array-mixed-types-ints-and-floats.toml"
-);
-t!(
-    test_array_mixed_types_strings_and_ints,
-    "Mixed types in array",
-    "fixtures/invalid/array-mixed-types-strings-and-ints.toml"
-);
-t!(
     test_datetime_malformed_no_leads,
     "While parsing a Date-Time",
     "fixtures/invalid/datetime-malformed-no-leads.toml"

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -32,7 +32,6 @@ macro_rules! parse_error {
 
 #[test]
 fn test_parse_error() {
-    parse_error!(r#"["", 2]"#, Value, "Mixed types in array");
     parse_error!("'hello'bla", Value, "Could not parse the line");
     parse_error!(r#"{a = 2"#, Value, "Expected `}`");
 


### PR DESCRIPTION
BREAKING CHANGE: Array functions that returned a `Result` to report
mixed-type arrays no longer do so.