### PR TITLE
test: Enable underscore test

### DIFF
--- a/tests/decoder_compliance.rs
+++ b/tests/decoder_compliance.rs
@@ -12,7 +12,6 @@ fn main() {
             "valid/datetime/milliseconds.toml",
             "valid/datetime/timezone.toml",
             "valid/example.toml",
-            "valid/float/underscore.toml",
             "valid/float/zero.toml",
             "valid/inline-table/key-dotted.toml",
             "valid/key/dotted.toml",


### PR DESCRIPTION
The root cause of this was a bug in the test harness.