### PR TITLE
feat: Publicly expose `DateTime`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,5 +84,5 @@ pub use crate::document::Document;
 pub use crate::key::Key;
 pub use crate::parser::TomlError;
 pub use crate::table::{array, table, value, Item, Iter, IterMut, Table, TableLike};
-pub use crate::value::{Array, ArrayIter, InlineTable, Value};
+pub use crate::value::{Array, ArrayIter, DateTime, InlineTable, Value};
 pub use formatted::decorated;

--- a/tests/decoder_compliance.rs
+++ b/tests/decoder_compliance.rs
@@ -6,8 +6,6 @@ fn main() {
             "valid/array/array.toml",
             "valid/comment/everywhere.toml",
             "valid/datetime/datetime.toml",
-            "valid/datetime/local-date.toml",
-            "valid/datetime/local-time.toml",
             "valid/datetime/local.toml",
             "valid/datetime/milliseconds.toml",
             "valid/datetime/timezone.toml",
@@ -72,9 +70,20 @@ fn value_to_encoded(
         toml_edit::Value::Float(v) => Ok(toml_test_harness::Encoded::Value(
             toml_test_harness::EncodedValue::from(*v.value()),
         )),
-        toml_edit::Value::DateTime(v) => Ok(toml_test_harness::Encoded::Value(
-            toml_test_harness::EncodedValue::from(v.value().to_string()),
-        )),
+        toml_edit::Value::DateTime(v) => match *v.value() {
+            toml_edit::DateTime::OffsetDateTime(v) => Ok(toml_test_harness::Encoded::Value(
+                toml_test_harness::EncodedValue::from(v.to_string()),
+            )),
+            toml_edit::DateTime::LocalDateTime(v) => Ok(toml_test_harness::Encoded::Value(
+                toml_test_harness::EncodedValue::DatetimeLocal(v.to_string()),
+            )),
+            toml_edit::DateTime::LocalDate(v) => Ok(toml_test_harness::Encoded::Value(
+                toml_test_harness::EncodedValue::DateLocal(v.to_string()),
+            )),
+            toml_edit::DateTime::LocalTime(v) => Ok(toml_test_harness::Encoded::Value(
+                toml_test_harness::EncodedValue::TimeLocal(v.to_string()),
+            )),
+        },
         toml_edit::Value::Boolean(v) => Ok(toml_test_harness::Encoded::Value(
             toml_test_harness::EncodedValue::from(*v.value()),
         )),


### PR DESCRIPTION
This let's us test more cases we were already handling correctly.

Downside is that we are exposing `chrono` in the API.

I think we should flatten `DateTime` into `Value` but I want to defer
that conversation, rather than have it block all of this moving forward.

Fixes #113