### PR TITLE
fix(datetime): Remove chrono from API

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,0 +1,134 @@
+use crate::parser;
+use std::str::FromStr;
+
+/// A RFC-3339 formatted TOML date/time w/ timezone
+///
+/// # Examples
+///
+/// ```rust
+/// let raw = "1996-12-19T16:39:57-08:00";
+/// let toml: toml_edit::OffsetDateTime = raw.parse().unwrap();
+/// let backagain = toml.to_string();
+/// assert_eq!(raw, backagain);
+/// ```
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+pub struct OffsetDateTime {
+    pub(crate) inner: chrono::DateTime<chrono::FixedOffset>,
+}
+
+impl FromStr for OffsetDateTime {
+    type Err = parser::TomlError;
+
+    /// Parses a value from a &str
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner = chrono::DateTime::parse_from_rfc3339(s)
+            .map_err(|e| parser::TomlError::custom(e.to_string()))?;
+        Ok(Self { inner })
+    }
+}
+
+impl std::fmt::Display for OffsetDateTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let s = self.inner.to_rfc3339();
+        s.fmt(f)
+    }
+}
+
+/// A RFC-3339 formatted TOML date/time w/o timezone
+///
+/// # Examples
+///
+/// ```rust
+/// let raw = "1996-12-19T16:39:57";
+/// let toml: toml_edit::LocalDateTime = raw.parse().unwrap();
+/// let backagain = toml.to_string();
+/// assert_eq!(raw, backagain);
+/// ```
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+pub struct LocalDateTime {
+    pub(crate) inner: chrono::NaiveDateTime,
+}
+
+impl FromStr for LocalDateTime {
+    type Err = parser::TomlError;
+
+    /// Parses a value from a &str
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+            .map_err(|e| parser::TomlError::custom(e.to_string()))?;
+        Ok(Self { inner })
+    }
+}
+
+impl std::fmt::Display for LocalDateTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let s = self.inner.format("%Y-%m-%dT%H:%M:%S%.f");
+        s.fmt(f)
+    }
+}
+
+/// A RFC-3339 formatted TOML date
+///
+/// # Examples
+///
+/// ```rust
+/// let raw = "1996-12-19";
+/// let toml: toml_edit::LocalDate = raw.parse().unwrap();
+/// let backagain = toml.to_string();
+/// assert_eq!(raw, backagain);
+/// ```
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+pub struct LocalDate {
+    pub(crate) inner: chrono::NaiveDate,
+}
+
+impl FromStr for LocalDate {
+    type Err = parser::TomlError;
+
+    /// Parses a value from a &str
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner = s
+            .parse::<chrono::NaiveDate>()
+            .map_err(|e| parser::TomlError::custom(e.to_string()))?;
+        Ok(Self { inner })
+    }
+}
+
+impl std::fmt::Display for LocalDate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        self.inner.fmt(f)
+    }
+}
+
+/// A RFC-3339 formatted TOML time
+///
+/// # Examples
+///
+/// ```rust
+/// let raw = "23:56:04.000123456";
+/// let toml: toml_edit::LocalTime = raw.parse().unwrap();
+/// let backagain = toml.to_string();
+/// assert_eq!(raw, backagain);
+/// ```
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+pub struct LocalTime {
+    pub(crate) inner: chrono::NaiveTime,
+}
+
+impl FromStr for LocalTime {
+    type Err = parser::TomlError;
+
+    /// Parses a value from a &str
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let inner = s
+            .parse::<chrono::NaiveTime>()
+            .map_err(|e| parser::TomlError::custom(e.to_string()))?;
+        Ok(Self { inner })
+    }
+}
+
+impl std::fmt::Display for LocalTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        self.inner.fmt(f)
+    }
+}

--- a/src/decor.rs
+++ b/src/decor.rs
@@ -26,7 +26,7 @@ pub(crate) type InternalString = String;
 
 impl Decor {
     /// Creates a new decor from the given prefix and suffix.
-    pub fn new<S: Into<InternalString>>(prefix: S, suffix: S) -> Self {
+    pub fn new(prefix: impl Into<String>, suffix: impl Into<String>) -> Self {
         Self {
             prefix: prefix.into(),
             suffix: suffix.into(),
@@ -45,11 +45,21 @@ impl Decor {
 }
 
 impl Repr {
-    pub fn new<S: Into<InternalString>>(prefix: S, value: S, suffix: S) -> Self {
+    pub fn new(
+        prefix: impl Into<InternalString>,
+        value: impl Into<InternalString>,
+        suffix: impl Into<InternalString>,
+    ) -> Self {
         Repr {
             decor: Decor::new(prefix, suffix),
             raw_value: value.into(),
         }
+    }
+}
+
+impl<D: std::fmt::Display> From<&D> for Repr {
+    fn from(other: &D) -> Self {
+        Self::new("", other.to_string(), "")
     }
 }
 
@@ -72,5 +82,12 @@ impl<T> Formatted<T> {
 
     pub(crate) fn new(v: T, repr: Repr) -> Self {
         Self { value: v, repr }
+    }
+}
+
+impl<D: std::fmt::Display> From<D> for Formatted<D> {
+    fn from(other: D) -> Self {
+        let repr = Repr::from(&other);
+        Self { value: other, repr }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 use crate::decor::{Formatted, Repr};
 use crate::document::Document;
 use crate::table::{Item, Table};
-use crate::value::{Array, DateTime, InlineTable, Value};
+use crate::value::{Array, InlineTable, Value};
 use std::fmt::{Display, Formatter, Result, Write};
 
 impl Display for Repr {
@@ -20,17 +20,6 @@ impl<T> Display for Formatted<T> {
     }
 }
 
-impl Display for DateTime {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match *self {
-            DateTime::OffsetDateTime(d) => write!(f, "{}", d),
-            DateTime::LocalDateTime(d) => write!(f, "{}", d),
-            DateTime::LocalDate(d) => write!(f, "{}", d),
-            DateTime::LocalTime(d) => write!(f, "{}", d),
-        }
-    }
-}
-
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match *self {
@@ -38,7 +27,10 @@ impl Display for Value {
             Value::String(ref repr) => write!(f, "{}", repr),
             Value::Float(ref repr) => write!(f, "{}", repr),
             Value::Boolean(ref repr) => write!(f, "{}", repr),
-            Value::DateTime(ref repr) => write!(f, "{}", repr),
+            Value::OffsetDateTime(ref repr) => write!(f, "{}", repr),
+            Value::LocalDateTime(ref repr) => write!(f, "{}", repr),
+            Value::LocalDate(ref repr) => write!(f, "{}", repr),
+            Value::LocalTime(ref repr) => write!(f, "{}", repr),
             Value::Array(ref array) => write!(f, "{}", array),
             Value::InlineTable(ref table) => write!(f, "{}", table),
         }

--- a/src/formatted.rs
+++ b/src/formatted.rs
@@ -1,9 +1,10 @@
+use crate::datetime::*;
 use crate::decor::{Decor, Formatted, InternalString, Repr};
 use crate::key::Key;
 use crate::parser::strings;
 use crate::parser::TomlError;
 use crate::table::{Item, KeyValuePairs, TableKeyValue};
-use crate::value::{Array, DateTime, InlineTable, Value};
+use crate::value::{Array, InlineTable, Value};
 use combine::stream::position::Stream as PositionStream;
 use std::iter::FromIterator;
 
@@ -48,7 +49,10 @@ pub(crate) fn decorate(value: &mut Value, prefix: &str, suffix: &str) {
         Value::Integer(ref mut f) => &mut f.repr.decor,
         Value::String(ref mut f) => &mut f.repr.decor,
         Value::Float(ref mut f) => &mut f.repr.decor,
-        Value::DateTime(ref mut f) => &mut f.repr.decor,
+        Value::OffsetDateTime(ref mut f) => &mut f.repr.decor,
+        Value::LocalDateTime(ref mut f) => &mut f.repr.decor,
+        Value::LocalDate(ref mut f) => &mut f.repr.decor,
+        Value::LocalTime(ref mut f) => &mut f.repr.decor,
         Value::Boolean(ref mut f) => &mut f.repr.decor,
         Value::Array(ref mut a) => &mut a.decor,
         Value::InlineTable(ref mut t) => &mut t.decor,
@@ -83,7 +87,16 @@ pub(crate) fn value(mut val: Value, raw: &str) -> Value {
         Value::Float(ref mut f) => {
             f.repr.raw_value = InternalString::from(raw);
         }
-        Value::DateTime(ref mut f) => {
+        Value::OffsetDateTime(ref mut f) => {
+            f.repr.raw_value = InternalString::from(raw);
+        }
+        Value::LocalDateTime(ref mut f) => {
+            f.repr.raw_value = InternalString::from(raw);
+        }
+        Value::LocalDate(ref mut f) => {
+            f.repr.raw_value = InternalString::from(raw);
+        }
+        Value::LocalTime(ref mut f) => {
             f.repr.raw_value = InternalString::from(raw);
         }
         Value::Boolean(ref mut f) => {
@@ -195,10 +208,40 @@ impl From<bool> for Value {
     }
 }
 
-impl From<DateTime> for Value {
-    fn from(d: DateTime) -> Self {
+impl From<OffsetDateTime> for Value {
+    fn from(d: OffsetDateTime) -> Self {
         let s = d.to_string();
-        Value::DateTime(Formatted::new(
+        Value::OffsetDateTime(Formatted::new(
+            d,
+            Repr::new("".to_string(), s, "".to_string()),
+        ))
+    }
+}
+
+impl From<LocalDateTime> for Value {
+    fn from(d: LocalDateTime) -> Self {
+        let s = d.to_string();
+        Value::LocalDateTime(Formatted::new(
+            d,
+            Repr::new("".to_string(), s, "".to_string()),
+        ))
+    }
+}
+
+impl From<LocalDate> for Value {
+    fn from(d: LocalDate) -> Self {
+        let s = d.to_string();
+        Value::LocalDate(Formatted::new(
+            d,
+            Repr::new("".to_string(), s, "".to_string()),
+        ))
+    }
+}
+
+impl From<LocalTime> for Value {
+    fn from(d: LocalTime) -> Self {
+        let s = d.to_string();
+        Value::LocalTime(Formatted::new(
             d,
             Repr::new("".to_string(), s, "".to_string()),
         ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 //! [test]: https://github.com/ordian/toml_edit/blob/f09bd5d075fdb7d2ef8d9bb3270a34506c276753/tests/test_valid.rs#L84
 
 mod array_of_tables;
+mod datetime;
 mod decor;
 mod display;
 mod document;
@@ -79,10 +80,11 @@ mod table;
 mod value;
 
 pub use crate::array_of_tables::ArrayOfTables;
+pub use crate::datetime::*;
 pub use crate::decor::Decor;
 pub use crate::document::Document;
 pub use crate::key::Key;
 pub use crate::parser::TomlError;
 pub use crate::table::{array, table, value, Item, Iter, IterMut, Table, TableLike};
-pub use crate::value::{Array, ArrayIter, DateTime, InlineTable, Value};
+pub use crate::value::{Array, ArrayIter, InlineTable, Value};
 pub use formatted::decorated;

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -23,6 +23,10 @@ impl TomlError {
             input,
         )
     }
+
+    pub(crate) fn custom(message: String) -> Self {
+        Self { message }
+    }
 }
 
 /// Displays a TOML parse error

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -111,8 +111,7 @@ mod tests {
             let (v, rest) = parsed.unwrap();
             assert_eq!(v.to_string(), *$input);
             assert!(rest.input.is_empty());
-            assert!(v.is_date_time());
-            assert!(v.as_date_time().unwrap().$is());
+            assert!(v.$is());
         }};
     }
 
@@ -277,7 +276,7 @@ trimmed in raw strings.
             "1979-05-27T00:32:00.999999-07:00",
         ];
         for input in &inputs {
-            parsed_date_time_eq!(input, is_offset_date_time);
+            parsed_date_time_eq!(input, is_offset_datetime);
         }
     }
 
@@ -285,7 +284,7 @@ trimmed in raw strings.
     fn local_date_time() {
         let inputs = ["1979-05-27T07:32:00", "1979-05-27T00:32:00.999999"];
         for input in &inputs {
-            parsed_date_time_eq!(input, is_local_date_time);
+            parsed_date_time_eq!(input, is_local_datetime);
         }
     }
 

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -137,7 +137,7 @@ impl TomlParser {
 
         match table {
             Ok(table) => {
-                let decor = Decor::new(leading, trailing.into());
+                let decor = Decor::new(leading, trailing);
 
                 let entry = table.entry(key.raw());
                 if entry.is_none() {
@@ -180,7 +180,7 @@ impl TomlParser {
         match table {
             Ok(table) => {
                 if !table.contains_table(key.get()) && !table.contains_value(key.get()) {
-                    let decor = Decor::new(leading, trailing.into());
+                    let decor = Decor::new(leading, trailing);
 
                     let entry = table
                         .entry(key.raw())

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -17,7 +17,7 @@ parse!(value() -> v::Value, {
             .map(|s|
                  v::Value::String(Formatted::new(
                      s,
-                     Repr::new("".to_string(), "who cares?".into(), "".to_string()),
+                     Repr::new("", "who cares?", ""),
                  ))
             ),
         boolean()

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -26,8 +26,7 @@ parse!(value() -> v::Value, {
             .map(v::Value::Array),
         inline_table()
             .map(v::Value::InlineTable),
-        date_time()
-            .map(v::Value::from),
+        date_time(),
         float()
             .map(v::Value::from),
         integer()

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,8 +1,9 @@
 use crate::array_of_tables::ArrayOfTables;
+use crate::datetime::*;
 use crate::decor::{Decor, InternalString, Repr};
 use crate::formatted::{decorated, key_repr};
 use crate::key::Key;
-use crate::value::{sort_key_value_pairs, Array, DateTime, InlineTable, Value};
+use crate::value::{sort_key_value_pairs, Array, InlineTable, Value};
 use linked_hash_map::LinkedHashMap;
 
 // TODO: add method to convert a table into inline table
@@ -340,13 +341,43 @@ impl Item {
     }
 
     /// Casts `self` to date-time.
-    pub fn as_date_time(&self) -> Option<&DateTime> {
-        self.as_value().and_then(Value::as_date_time)
+    pub fn as_offset_datetime(&self) -> Option<&OffsetDateTime> {
+        self.as_value().and_then(Value::as_offset_datetime)
     }
 
     /// Returns true iff `self` is a date-time.
-    pub fn is_date_time(&self) -> bool {
-        self.as_date_time().is_some()
+    pub fn is_offset_datetime(&self) -> bool {
+        self.as_offset_datetime().is_some()
+    }
+
+    /// Casts `self` to date-time.
+    pub fn as_local_datetime(&self) -> Option<&LocalDateTime> {
+        self.as_value().and_then(Value::as_local_datetime)
+    }
+
+    /// Returns true iff `self` is a date-time.
+    pub fn is_local_datetime(&self) -> bool {
+        self.as_local_datetime().is_some()
+    }
+
+    /// Casts `self` to date-time.
+    pub fn as_local_date(&self) -> Option<&LocalDate> {
+        self.as_value().and_then(Value::as_local_date)
+    }
+
+    /// Returns true iff `self` is a date-time.
+    pub fn is_local_date(&self) -> bool {
+        self.as_local_date().is_some()
+    }
+
+    /// Casts `self` to date-time.
+    pub fn as_local_time(&self) -> Option<&LocalTime> {
+        self.as_value().and_then(Value::as_local_time)
+    }
+
+    /// Returns true iff `self` is a date-time.
+    pub fn is_local_time(&self) -> bool {
+        self.as_local_time().is_some()
     }
 
     /// Casts `self` to array.

--- a/tests/decoder_compliance.rs
+++ b/tests/decoder_compliance.rs
@@ -61,20 +61,18 @@ fn value_to_encoded(
         toml_edit::Value::Float(v) => Ok(toml_test_harness::Encoded::Value(
             toml_test_harness::EncodedValue::from(*v.value()),
         )),
-        toml_edit::Value::DateTime(v) => match *v.value() {
-            toml_edit::DateTime::OffsetDateTime(v) => Ok(toml_test_harness::Encoded::Value(
-                toml_test_harness::EncodedValue::Datetime(v.to_rfc3339()),
-            )),
-            toml_edit::DateTime::LocalDateTime(v) => Ok(toml_test_harness::Encoded::Value(
-                toml_test_harness::EncodedValue::DatetimeLocal(v.to_string()),
-            )),
-            toml_edit::DateTime::LocalDate(v) => Ok(toml_test_harness::Encoded::Value(
-                toml_test_harness::EncodedValue::DateLocal(v.to_string()),
-            )),
-            toml_edit::DateTime::LocalTime(v) => Ok(toml_test_harness::Encoded::Value(
-                toml_test_harness::EncodedValue::TimeLocal(v.to_string()),
-            )),
-        },
+        toml_edit::Value::OffsetDateTime(v) => Ok(toml_test_harness::Encoded::Value(
+            toml_test_harness::EncodedValue::Datetime(v.value().to_string()),
+        )),
+        toml_edit::Value::LocalDateTime(v) => Ok(toml_test_harness::Encoded::Value(
+            toml_test_harness::EncodedValue::DatetimeLocal(v.value().to_string()),
+        )),
+        toml_edit::Value::LocalDate(v) => Ok(toml_test_harness::Encoded::Value(
+            toml_test_harness::EncodedValue::DateLocal(v.value().to_string()),
+        )),
+        toml_edit::Value::LocalTime(v) => Ok(toml_test_harness::Encoded::Value(
+            toml_test_harness::EncodedValue::TimeLocal(v.value().to_string()),
+        )),
         toml_edit::Value::Boolean(v) => Ok(toml_test_harness::Encoded::Value(
             toml_test_harness::EncodedValue::from(*v.value()),
         )),

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -54,12 +54,12 @@ fn test_key_from_str() {
 
 #[test]
 fn test_value_from_str() {
-    assert!(parse_value!("1979-05-27T00:32:00.999999-07:00").is_date_time());
-    assert!(parse_value!("1979-05-27T00:32:00.999999Z").is_date_time());
-    assert!(parse_value!("1979-05-27T00:32:00.999999").is_date_time());
-    assert!(parse_value!("1979-05-27T00:32:00").is_date_time());
-    assert!(parse_value!("1979-05-27").is_date_time());
-    assert!(parse_value!("00:32:00").is_date_time());
+    assert!(parse_value!("1979-05-27T00:32:00.999999-07:00").is_offset_datetime());
+    assert!(parse_value!("1979-05-27T00:32:00.999999Z").is_offset_datetime());
+    assert!(parse_value!("1979-05-27T00:32:00.999999").is_local_datetime());
+    assert!(parse_value!("1979-05-27T00:32:00").is_local_datetime());
+    assert!(parse_value!("1979-05-27").is_local_date());
+    assert!(parse_value!("00:32:00").is_local_time());
     assert!(parse_value!("-239").is_integer());
     assert!(parse_value!("1e200").is_float());
     assert!(parse_value!("9_224_617.445_991_228_313").is_float());

--- a/tests/test_valid.rs
+++ b/tests/test_valid.rs
@@ -17,7 +17,10 @@ fn pair_to_json((key, value): (&str, Item)) -> (String, Json) {
             Value::Integer(ref i) => typed_json("integer", Json::String(format!("{}", i.value()))),
             Value::Float(ref f) => typed_json("float", Json::String(format!("{}", f.value()))),
             Value::Boolean(ref b) => typed_json("bool", Json::String(b.raw().into())),
-            Value::DateTime(ref d) => typed_json("datetime", Json::String(d.raw().into())),
+            Value::OffsetDateTime(ref d) => typed_json("datetime", Json::String(d.raw().into())),
+            Value::LocalDateTime(ref d) => typed_json("datetime", Json::String(d.raw().into())),
+            Value::LocalDate(ref d) => typed_json("datetime", Json::String(d.raw().into())),
+            Value::LocalTime(ref d) => typed_json("datetime", Json::String(d.raw().into())),
             Value::Array(ref a) => {
                 let json = Json::Array(a.iter().map(value_to_json).collect::<Vec<_>>());
                 typed_json("array", json)


### PR DESCRIPTION
This creates newtypes for each date/time type that enforce their format
and allow conversion to/from it by the user.

This also flattens `DateTime` into `Value`.

This is part of #122