### PR TITLE
fix!: Make order-preserving the default

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -202,7 +202,7 @@ impl Display for Table {
 impl Document {
     /// Returns a string representation of the TOML document, attempting to keep
     /// the table headers in their original order.
-    pub fn to_string_in_original_order(&self) -> String {
+    fn to_string_in_original_order(&self) -> String {
         let mut string = String::new();
         let mut path = Vec::new();
         let mut last_position = 0;
@@ -230,8 +230,8 @@ impl Document {
 
 impl Display for Document {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self.as_table())?;
-        write!(f, "{}", self.trailing)
+        let s = self.to_string_in_original_order();
+        s.fmt(f)
     }
 }
 

--- a/tests/test_valid.rs
+++ b/tests/test_valid.rs
@@ -82,36 +82,6 @@ macro_rules! t(
 );
 
 #[test]
-fn test_table_reordering() {
-    let toml = r#"
-[[bin]] # bin 1
-[a.b.c.e]
-[a]
-[other.table]
-[[bin]] # bin 2
-[a.b.c.d]
-[a.b.c]
-[[bin]] # bin 3
-"#;
-    let expected = r#"
-[[bin]] # bin 1
-[[bin]] # bin 2
-[[bin]] # bin 3
-[a]
-[a.b.c]
-[a.b.c.e]
-[a.b.c.d]
-[other.table]
-"#;
-    let doc = toml.parse::<Document>();
-    assert!(doc.is_ok());
-    let doc = doc.unwrap();
-
-    assert_eq!(doc.to_string(), expected);
-    assert_eq!(doc.to_string_in_original_order(), toml);
-}
-
-#[test]
 fn test_key_unification() {
     let toml = r#"
 [a]
@@ -130,7 +100,6 @@ fn test_key_unification() {
     let doc = doc.unwrap();
 
     assert_eq!(doc.to_string(), expected);
-    assert_eq!(doc.to_string_in_original_order(), expected);
 }
 
 t!(


### PR DESCRIPTION
This will make things less surprising, especially as we add key order
preserving with dotted keys

This could use some optimization since we no longer need to build directly into the string anymore

BREAKING CHANGE: `to_string_in_original_order` is gone, see `to_display`