### PR TITLE
refactor: Embed Key into TableyKeyValue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4.10"
 linked-hash-map = "0.5.2"
 combine = "4.5.2"
 vec1 = "1"
+itertools = "0.10"
 
 [dev-dependencies]
 serde_json = "1.0.44"

--- a/src/index.rs
+++ b/src/index.rs
@@ -61,7 +61,7 @@ impl Index for str {
             let mut t = InlineTable::default();
             t.items.insert(
                 key.get().to_owned(),
-                TableKeyValue::new(key.repr().to_owned(), Item::None),
+                TableKeyValue::new(key.clone(), Item::None),
             );
             *v = value(Value::InlineTable(t));
         }
@@ -73,10 +73,10 @@ impl Index for str {
                     .unwrap()
                     .items
                     .entry(key.get().to_owned())
-                    .or_insert(TableKeyValue::new(key.repr().to_owned(), Item::None))
+                    .or_insert(TableKeyValue::new(key, Item::None))
                     .value
             }
-            _ => panic!("cannot access key {}", key),
+            _ => panic!("cannot access key {}", self),
         }
     }
 }

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -87,10 +87,7 @@ impl InlineTable {
         let key = Key::with_key(key);
         self.items
             .entry(key.get().to_owned())
-            .or_insert(TableKeyValue::new(
-                key.into_repr(),
-                Item::Value(value.into()),
-            ))
+            .or_insert(TableKeyValue::new(key, Item::Value(value.into())))
             .value
             .as_value_mut()
             .expect("non-value type in inline table")
@@ -98,7 +95,7 @@ impl InlineTable {
 
     /// Inserts a key-value pair into the map.
     pub fn insert_formatted(&mut self, key: &Key, value: Value) -> Option<Value> {
-        let kv = TableKeyValue::new(key.repr().to_owned(), Item::Value(value));
+        let kv = TableKeyValue::new(key.to_owned(), Item::Value(value));
         self.items
             .insert(key.get().to_owned(), kv)
             .filter(|kv| kv.value.is_value())
@@ -133,8 +130,8 @@ impl<K: Into<Key>, V: Into<Value>> Extend<(K, V)> for InlineTable {
         for (key, value) in iter {
             let key = key.into();
             let value = Item::Value(value.into());
-            let value = TableKeyValue::new(key.repr().to_owned(), value);
-            self.items.insert(key.into(), value);
+            let value = TableKeyValue::new(key, value);
+            self.items.insert(value.key.get().to_owned(), value);
         }
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 use linked_hash_map::LinkedHashMap;
 
 use crate::key::Key;
-use crate::repr::{Decor, InternalString, Repr};
+use crate::repr::{Decor, InternalString};
 use crate::value::DEFAULT_VALUE_DECOR;
 use crate::{Item, Value};
 
@@ -90,7 +90,7 @@ impl Table {
         &mut self
             .items
             .entry(key.get().to_owned())
-            .or_insert_with(|| TableKeyValue::new(key.repr().to_owned(), Item::None))
+            .or_insert_with(|| TableKeyValue::new(key, Item::None))
             .value
     }
 
@@ -104,7 +104,7 @@ impl Table {
         &mut self
             .items
             .entry(key.get().to_owned())
-            .or_insert_with(|| TableKeyValue::new(key.repr().to_owned(), Item::None))
+            .or_insert_with(|| TableKeyValue::new(key.to_owned(), Item::None))
             .value
     }
 
@@ -156,7 +156,7 @@ impl Table {
 
     /// Inserts a key-value pair into the map.
     pub fn insert_formatted(&mut self, key: &Key, item: Item) -> Option<Item> {
-        let kv = TableKeyValue::new(key.repr().to_owned(), item);
+        let kv = TableKeyValue::new(key.to_owned(), item);
         self.items
             .insert(key.get().to_owned(), kv)
             .map(|kv| kv.value)
@@ -229,8 +229,8 @@ impl<K: Into<Key>, V: Into<Value>> Extend<(K, V)> for Table {
         for (key, value) in iter {
             let key = key.into();
             let value = Item::Value(value.into());
-            let value = TableKeyValue::new(key.repr().to_owned(), value);
-            self.items.insert(key.into(), value);
+            let value = TableKeyValue::new(key, value);
+            self.items.insert(value.key.get().to_owned(), value);
         }
     }
 }
@@ -297,15 +297,15 @@ pub(crate) const DEFAULT_TABLE_DECOR: (&str, &str) = ("\n", "");
 
 #[derive(Debug, Clone)]
 pub(crate) struct TableKeyValue {
-    pub(crate) key_repr: Repr,
+    pub(crate) key: Key,
     pub(crate) key_decor: Decor,
     pub(crate) value: Item,
 }
 
 impl TableKeyValue {
-    pub(crate) fn new(key_repr: Repr, value: Item) -> Self {
+    pub(crate) fn new(key: Key, value: Item) -> Self {
         TableKeyValue {
-            key_repr,
+            key,
             key_decor: Default::default(),
             value,
         }


### PR DESCRIPTION
This is several levels removed from dotted key support.  We need to
preserve decor for key paths, which we don't currently do.  To do this,
we need to store it in `Key`.  To do this, we need `Key` in
`TableKeyValue`.