### PR TITLE
fix: Preserve a key's Decor in table headers

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -6,7 +6,7 @@ use crate::document::Document;
 use crate::inline_table::DEFAULT_INLINE_KEY_DECOR;
 use crate::key::Key;
 use crate::repr::{DecorDisplay, Formatted, Repr};
-use crate::table::{DEFAULT_KEY_DECOR, DEFAULT_TABLE_DECOR};
+use crate::table::{DEFAULT_KEY_DECOR, DEFAULT_KEY_PATH_DECOR, DEFAULT_TABLE_DECOR};
 use crate::value::DEFAULT_VALUE_DECOR;
 use crate::{Array, InlineTable, Item, Table, Value};
 
@@ -36,6 +36,7 @@ impl<T> Display for Formatted<T> {
 
 impl Display for Key {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        // HACK: For now, leaving off decor since we don't know the defaults to use in this context
         self.repr().fmt(f)
     }
 }
@@ -91,7 +92,7 @@ impl Display for InlineTable {
             .filter(|&(_, kv)| kv.value.is_value())
             .map(|(_, kv)| {
                 (
-                    kv.key_decor.display(&kv.key, DEFAULT_INLINE_KEY_DECOR),
+                    kv.key.decor.display(&kv.key, DEFAULT_INLINE_KEY_DECOR),
                     kv.value.as_value().unwrap(),
                 )
             })
@@ -157,7 +158,13 @@ fn visit_table(
             "{}[[",
             table.decor.prefix().unwrap_or(DEFAULT_TABLE_DECOR.0)
         )?;
-        write!(f, "{}", path.iter().join("."))?;
+        write!(
+            f,
+            "{}",
+            path.iter()
+                .map(|k| k.decor.display(k, DEFAULT_KEY_PATH_DECOR))
+                .join(".")
+        )?;
         writeln!(
             f,
             "]]{}",
@@ -169,7 +176,13 @@ fn visit_table(
             "{}[",
             table.decor.prefix().unwrap_or(DEFAULT_TABLE_DECOR.0)
         )?;
-        write!(f, "{}", path.iter().join("."))?;
+        write!(
+            f,
+            "{}",
+            path.iter()
+                .map(|k| k.decor.display(k, DEFAULT_KEY_PATH_DECOR))
+                .join(".")
+        )?;
         writeln!(
             f,
             "]{}",
@@ -182,7 +195,7 @@ fn visit_table(
             writeln!(
                 f,
                 "{}={}",
-                kv.key_decor.display(&kv.key, DEFAULT_KEY_DECOR),
+                kv.key.decor.display(&kv.key, DEFAULT_KEY_DECOR),
                 value
             )?;
         }

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -121,7 +121,7 @@ impl InlineTable {
 
     /// Returns the decor associated with a given key of the table.
     pub fn decor(&self, key: &str) -> Option<&Decor> {
-        self.items.get(key).map(|kv| &kv.key_decor)
+        self.items.get(key).map(|kv| &kv.key.decor)
     }
 }
 
@@ -176,7 +176,7 @@ fn decorate_inline_table(table: &mut InlineTable) {
         .items
         .iter_mut()
         .filter(|&(_, ref kv)| kv.value.is_value())
-        .map(|(_, kv)| (&mut kv.key_decor, kv.value.as_value_mut().unwrap()))
+        .map(|(_, kv)| (&mut kv.key.decor, kv.value.as_value_mut().unwrap()))
         .enumerate()
     {
         // { key1 = value1, key2 = value2 }

--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -59,14 +59,13 @@ parser! {
         ).map(|(k, _, v)| {
             let ((raw, key), suf) = k;
             let key_repr = Repr::new_unchecked(raw);
-            let key = Key::new(key_repr, key);
             let key_decor = Decor::new("", suf);
+            let key = Key::new_unchecked(key_repr, key, key_decor);
 
             let (pre, v, suf) = v;
             let v = v.decorated(pre, suf);
             TableKeyValue {
                 key,
-                key_decor,
                 value: Item::Value(v),
             }
         })
@@ -120,9 +119,9 @@ impl TomlParser {
 
     fn on_keyval(&mut self, mut kv: TableKeyValue) -> Result<(), CustomError> {
         let prefix = mem::take(&mut self.document.trailing);
-        kv.key_decor = Decor::new(
-            prefix + kv.key_decor.prefix().unwrap_or_default(),
-            kv.key_decor.suffix().unwrap_or_default(),
+        kv.key.decor = Decor::new(
+            prefix + kv.key.decor.prefix().unwrap_or_default(),
+            kv.key.decor.suffix().unwrap_or_default(),
         );
 
         let root = self.document.as_table_mut();

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -66,14 +66,13 @@ parse!(keyval() -> TableKeyValue, {
         (ws(), value(), ws()),
     ).map(|(k, _, v)| {
         let (pre, (raw, key), suf) = k;
-        let key = Key::new(Repr::new_unchecked(raw), key);
         let key_decor = Decor::new(pre, suf);
+        let key = Key::new_unchecked(Repr::new_unchecked(raw), key, key_decor);
 
         let (pre, v, suf) = v;
         let v = v.decorated(pre, suf);
         TableKeyValue {
             key,
-            key_decor,
             value: Item::Value(v),
         }
     })

--- a/src/parser/key.rs
+++ b/src/parser/key.rs
@@ -1,7 +1,7 @@
 use crate::key::Key;
 use crate::parser::strings::{basic_string, literal_string};
 use crate::parser::trivia::ws;
-use crate::repr::{InternalString, Repr};
+use crate::repr::{Decor, InternalString, Repr};
 use combine::parser::char::char;
 use combine::parser::range::{recognize_with_value, take_while1};
 use combine::stream::RangeStream;
@@ -12,7 +12,13 @@ use vec1::Vec1;
 // dotted-key = simple-key 1*( dot-sep simple-key )
 parse!(key() -> Vec1<Key>, {
     sep_by1(
-        between(ws(), ws(), simple_key().map(|(raw, key)| Key::new(Repr::new_unchecked(raw), key))),
+        (
+            ws(),
+            simple_key(),
+            ws(),
+        ).map(|(pre, (raw, key), suffix)| {
+            Key::new_unchecked(Repr::new_unchecked(raw), key, Decor::new(pre, suffix))
+        }),
         char(DOT_SEP)
     ).map(|k| Vec1::try_from_vec(k).expect("parser should guarantee this"))
 });

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -493,6 +493,9 @@ that
             r#"  "#,
             r#" hello = 'darkness' # my old friend
 "#,
+            r#"[parent . child]
+key = "value"
+"#,
         ];
         for document in &documents {
             let doc = TomlParser::parse(document);
@@ -500,6 +503,8 @@ that
             assert!(doc.is_ok());
             let doc = doc.unwrap();
 
+            dbg!(doc.to_string());
+            dbg!(document);
             assert_eq!(PrettyString(document), PrettyString(&doc.to_string()));
         }
 

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -62,7 +62,7 @@ impl Repr {
 /// A prefix and suffix,
 ///
 /// Including comments, whitespaces and newlines.
-#[derive(Eq, PartialEq, Clone, Default, Debug, Hash)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Default, Debug, Hash)]
 pub struct Decor {
     prefix: Option<InternalString>,
     suffix: Option<InternalString>,

--- a/src/table.rs
+++ b/src/table.rs
@@ -204,7 +204,7 @@ impl Table {
 
     /// Returns the decor associated with a given key of the table.
     pub fn decor(&self, key: &str) -> Option<&Decor> {
-        self.items.get(key).map(|kv| &kv.key_decor)
+        self.items.get(key).map(|kv| &kv.key.decor)
     }
 
     /// Sets the position of the `Table` within the `Document`.
@@ -283,7 +283,7 @@ fn decorate_table(table: &mut Table) {
         .items
         .iter_mut()
         .filter(|&(_, ref kv)| kv.value.is_value())
-        .map(|(_, kv)| (&mut kv.key_decor, kv.value.as_value_mut().unwrap()))
+        .map(|(_, kv)| (&mut kv.key.decor, kv.value.as_value_mut().unwrap()))
     {
         // `key1 = value1`
         *key_decor = Decor::new(DEFAULT_KEY_DECOR.0, DEFAULT_KEY_DECOR.1);
@@ -294,21 +294,17 @@ fn decorate_table(table: &mut Table) {
 // `key1 = value1`
 pub(crate) const DEFAULT_KEY_DECOR: (&str, &str) = ("", " ");
 pub(crate) const DEFAULT_TABLE_DECOR: (&str, &str) = ("\n", "");
+pub(crate) const DEFAULT_KEY_PATH_DECOR: (&str, &str) = ("", "");
 
 #[derive(Debug, Clone)]
 pub(crate) struct TableKeyValue {
     pub(crate) key: Key,
-    pub(crate) key_decor: Decor,
     pub(crate) value: Item,
 }
 
 impl TableKeyValue {
     pub(crate) fn new(key: Key, value: Item) -> Self {
-        TableKeyValue {
-            key,
-            key_decor: Default::default(),
-            value,
-        }
+        TableKeyValue { key, value }
     }
 }
 


### PR DESCRIPTION
This is minor on its own but a bigger deal for dotted keys.  Not even
for dotted keys itself but for preserving the start/end space for dotted
keys when switching out the parser.