### PR TITLE
feat: Basic dotted key support

### DIFF
--- a/tests/decoder_compliance.rs
+++ b/tests/decoder_compliance.rs
@@ -4,8 +4,6 @@ fn main() {
     harness
         .ignore([
             "valid/inline-table/key-dotted.toml",
-            "valid/key/dotted.toml",
-            "valid/key/numeric-dotted.toml",
             "valid/string/multiline-quotes.toml",
         ])
         .unwrap();


### PR DESCRIPTION
This let's us parse dotted keys in tables.

This does not include
- Format preserving
- Error if dotted keys insert into table
- Error if table insets into dotted keys
- Anything for inline tables

Part of #91 