### PR TITLE
fix: Make debug impls more readable

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -9,14 +9,14 @@ use crate::{Item, Value};
 /// payload of the `Value::Array` variant's value
 #[derive(Debug, Default, Clone)]
 pub struct Array {
-    // always Vec<Item::Value>
-    pub(crate) values: Vec<Item>,
     // `trailing` represents whitespaces, newlines
     // and comments in an empty array or after the trailing comma
     pub(crate) trailing: InternalString,
     pub(crate) trailing_comma: bool,
     // prefix before `[` and suffix after `]`
     pub(crate) decor: Decor,
+    // always Vec<Item::Value>
+    pub(crate) values: Vec<Item>,
 }
 
 /// An iterator type over `Array`'s values.

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -10,11 +10,11 @@ use crate::{Item, Value};
 /// payload of the `Value::InlineTable` variant
 #[derive(Debug, Default, Clone)]
 pub struct InlineTable {
-    pub(crate) items: KeyValuePairs,
     // `preamble` represents whitespaces in an empty table
     pub(crate) preamble: InternalString,
     // prefix before `{` and suffix after `}`
     pub(crate) decor: Decor,
+    pub(crate) items: KeyValuePairs,
 }
 
 impl InlineTable {

--- a/src/table.rs
+++ b/src/table.rs
@@ -10,7 +10,6 @@ use crate::{InlineTable, Item, Value};
 /// Type representing a TOML non-inline table
 #[derive(Clone, Debug, Default)]
 pub struct Table {
-    pub(crate) items: KeyValuePairs,
     // comments/spaces before and after the header
     pub(crate) decor: Decor,
     // whether to hide an empty table
@@ -18,6 +17,7 @@ pub struct Table {
     // used for putting tables back in their original order when serialising.
     // Will be None when the Table wasn't parsed from a file.
     pub(crate) position: Option<usize>,
+    pub(crate) items: KeyValuePairs,
 }
 
 impl Table {


### PR DESCRIPTION
By having the deeply nexted items last, we can more easily see the
metadata for the item vs trying to match up the end with the start.