### PR TITLE
fix: Clarify get_children's name

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -88,7 +88,7 @@ impl Display for InlineTable {
         write!(f, "{}", self.preamble)?;
 
         let mut children = Vec::new();
-        self.get_children(&mut children);
+        self.get_values(&mut children);
         for (i, (key_path, value)) in children.into_iter().enumerate() {
             let key = key_path_display(&key_path, DEFAULT_INLINE_KEY_DECOR);
             if i > 0 {
@@ -145,7 +145,7 @@ fn visit_table(
     is_array_of_tables: bool,
 ) -> Result {
     let mut children = Vec::new();
-    table.get_children(&mut children);
+    table.get_values(&mut children);
 
     if path.is_empty() {
         // don't print header for the root node

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -174,12 +174,12 @@ impl InlineTable {
     /// Get key/values for values that are visually children of this table
     ///
     /// For example, this will return dotted keys
-    pub fn get_children<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
+    pub fn get_values<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
         let root = Vec::new();
-        self.get_children_internal(&root, children);
+        self.get_values_internal(&root, children);
     }
 
-    fn get_children_internal<'s, 'c>(
+    fn get_values_internal<'s, 'c>(
         &'s self,
         parent: &[&'s Key],
         children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>,
@@ -189,7 +189,7 @@ impl InlineTable {
             path.push(&value.key);
             match &value.value {
                 Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
-                    table.get_children_internal(&path, children);
+                    table.get_values_internal(&path, children);
                 }
                 Item::Value(value) => {
                     children.push((path, value));

--- a/src/table.rs
+++ b/src/table.rs
@@ -82,7 +82,7 @@ impl Table {
 
     /// Returns the number of key/value pairs in the table.
     ///
-    /// NOTE: Not accurate for dotted keys, see `get_children`
+    /// NOTE: Not accurate for dotted keys, see `get_values`
     pub(crate) fn values_len(&self) -> usize {
         self.items.iter().filter(|i| (i.1).value.is_value()).count()
     }
@@ -189,12 +189,12 @@ impl Table {
     /// Get key/values for values that are visually children of this table
     ///
     /// For example, this will return dotted keys
-    pub fn get_children<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
+    pub fn get_values<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
         let root = Vec::new();
-        self.get_children_internal(&root, children);
+        self.get_values_internal(&root, children);
     }
 
-    fn get_children_internal<'s, 'c>(
+    fn get_values_internal<'s, 'c>(
         &'s self,
         parent: &[&'s Key],
         children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>,
@@ -204,7 +204,7 @@ impl Table {
             path.push(&value.key);
             match &value.value {
                 Item::Table(table) if table.is_dotted() => {
-                    table.get_children_internal(&path, children);
+                    table.get_values_internal(&path, children);
                 }
                 Item::Value(value) => {
                     children.push((path, value));


### PR DESCRIPTION
When first implementing, I assumed `Table` would provide `Item`.  When i
found it needed to provide `Value`, I hadn't reconsidered a more
specific name.