### PR TITLE
fix: Clean up get_values API

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -87,8 +87,7 @@ impl Display for InlineTable {
         )?;
         write!(f, "{}", self.preamble)?;
 
-        let mut children = Vec::new();
-        self.get_values(&mut children);
+        let children = self.get_values();
         for (i, (key_path, value)) in children.into_iter().enumerate() {
             let key = key_path_display(&key_path, DEFAULT_INLINE_KEY_DECOR);
             if i > 0 {
@@ -144,8 +143,7 @@ fn visit_table(
     path: &[&Key],
     is_array_of_tables: bool,
 ) -> Result {
-    let mut children = Vec::new();
-    table.get_values(&mut children);
+    let children = table.get_values();
 
     if path.is_empty() {
         // don't print header for the root node

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -174,25 +174,27 @@ impl InlineTable {
     /// Get key/values for values that are visually children of this table
     ///
     /// For example, this will return dotted keys
-    pub fn get_values<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
+    pub fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
+        let mut values = Vec::new();
         let root = Vec::new();
-        self.get_values_internal(&root, children);
+        self.get_values_internal(&root, &mut values);
+        values
     }
 
     fn get_values_internal<'s, 'c>(
         &'s self,
         parent: &[&'s Key],
-        children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>,
+        values: &'c mut Vec<(Vec<&'s Key>, &'s Value)>,
     ) {
         for value in self.items.values() {
             let mut path = parent.to_vec();
             path.push(&value.key);
             match &value.value {
                 Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
-                    table.get_values_internal(&path, children);
+                    table.get_values_internal(&path, values);
                 }
                 Item::Value(value) => {
-                    children.push((path, value));
+                    values.push((path, value));
                 }
                 _ => {}
             }
@@ -309,8 +311,8 @@ impl TableLike for InlineTable {
     fn get_mut<'s>(&'s mut self, key: &str) -> Option<&'s mut Item> {
         self.items.get_mut(key).map(|kv| &mut kv.value)
     }
-    fn get_values<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
-        self.get_values(children);
+    fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
+        self.get_values()
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -189,25 +189,27 @@ impl Table {
     /// Get key/values for values that are visually children of this table
     ///
     /// For example, this will return dotted keys
-    pub fn get_values<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
+    pub fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
+        let mut values = Vec::new();
         let root = Vec::new();
-        self.get_values_internal(&root, children);
+        self.get_values_internal(&root, &mut values);
+        values
     }
 
     fn get_values_internal<'s, 'c>(
         &'s self,
         parent: &[&'s Key],
-        children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>,
+        values: &'c mut Vec<(Vec<&'s Key>, &'s Value)>,
     ) {
         for value in self.items.values() {
             let mut path = parent.to_vec();
             path.push(&value.key);
             match &value.value {
                 Item::Table(table) if table.is_dotted() => {
-                    table.get_values_internal(&path, children);
+                    table.get_values_internal(&path, values);
                 }
                 Item::Value(value) => {
-                    children.push((path, value));
+                    values.push((path, value));
                 }
                 _ => {}
             }
@@ -390,7 +392,7 @@ pub trait TableLike {
     /// Get key/values for values that are visually children of this table
     ///
     /// For example, this will return dotted keys
-    fn get_values<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>);
+    fn get_values(&self) -> Vec<(Vec<&Key>, &Value)>;
 }
 
 impl TableLike for Table {
@@ -404,8 +406,8 @@ impl TableLike for Table {
     fn get_mut<'s>(&'s mut self, key: &str) -> Option<&'s mut Item> {
         self.get_mut(key)
     }
-    fn get_values<'s, 'c>(&'s self, children: &'c mut Vec<(Vec<&'s Key>, &'s Value)>) {
-        self.get_values(children);
+    fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
+        self.get_values()
     }
 }
 


### PR DESCRIPTION
As the code evolved, the API didn't keep up with the simplifications that the new code allowed.