### PR TITLE
fix: Clean up `Key`s API

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -56,7 +56,7 @@ impl Index for str {
         }
     }
     fn index_or_insert<'v>(&self, v: &'v mut Item) -> &'v mut Item {
-        let key = Key::with_key(self);
+        let key = Key::new(self);
         if let Item::None = *v {
             let mut t = InlineTable::default();
             t.items.insert(

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -136,7 +136,7 @@ impl InlineTable {
     /// Inserts a key/value pair if the table does not contain the key.
     /// Returns a mutable reference to the corresponding value.
     pub fn get_or_insert<V: Into<Value>>(&mut self, key: &str, value: V) -> &mut Value {
-        let key = Key::with_key(key);
+        let key = Key::new(key);
         self.items
             .entry(key.get().to_owned())
             .or_insert(TableKeyValue::new(key, Item::Value(value.into())))
@@ -440,10 +440,7 @@ impl<'a> InlineVacantEntry<'a> {
     /// Sets the value of the entry with the VacantEntry's key,
     /// and returns a mutable reference to it
     pub fn insert(self, value: Value) -> &'a mut Value {
-        let key = self
-            .key
-            .cloned()
-            .unwrap_or_else(|| Key::with_key(self.key()));
+        let key = self.key.cloned().unwrap_or_else(|| Key::new(self.key()));
         let value = Item::Value(value);
         self.entry
             .insert(TableKeyValue::new(key, value))

--- a/src/key.rs
+++ b/src/key.rs
@@ -35,12 +35,23 @@ pub struct Key {
 }
 
 impl Key {
-    pub(crate) fn new_unchecked(repr: Repr, key: InternalString, decor: Decor) -> Self {
-        Self { key, repr, decor }
+    /// Create a new table key
+    pub fn new(key: impl AsRef<str>) -> Self {
+        key_string_repr(key.as_ref())
     }
 
-    pub(crate) fn with_key(key: impl AsRef<str>) -> Self {
-        key_string_repr(key.as_ref())
+    pub(crate) fn new_unchecked(repr: Repr, key: InternalString) -> Self {
+        Self {
+            key,
+            repr,
+            decor: Default::default(),
+        }
+    }
+
+    /// While creating the `Key`, add `Decor` to it
+    pub fn with_decor(mut self, decor: Decor) -> Self {
+        self.decor = decor;
+        self
     }
 
     /// Returns the parsed key value.
@@ -51,11 +62,6 @@ impl Key {
     /// Returns the key raw representation.
     pub fn repr(&self) -> &Repr {
         &self.repr
-    }
-
-    /// Returns the key raw representation.
-    pub fn into_repr(self) -> Repr {
-        self.repr
     }
 
     /// Returns the key raw representation.
@@ -75,11 +81,7 @@ impl Key {
             Ok((_, ref rest)) if !rest.input.is_empty() => {
                 Err(parser::TomlError::from_unparsed(rest.positioner, s))
             }
-            Ok(((raw, key), _)) => Ok(Key::new_unchecked(
-                Repr::new_unchecked(raw),
-                key,
-                Decor::default(),
-            )),
+            Ok(((raw, key), _)) => Ok(Key::new_unchecked(Repr::new_unchecked(raw), key)),
             Err(e) => Err(parser::TomlError::new(e, s)),
         }
     }
@@ -102,13 +104,13 @@ impl FromStr for Key {
 
 impl<'b> From<&'b str> for Key {
     fn from(s: &'b str) -> Self {
-        Key::with_key(s)
+        Key::new(s)
     }
 }
 
 impl From<String> for Key {
     fn from(s: String) -> Self {
-        Key::with_key(s)
+        Key::new(s)
     }
 }
 

--- a/src/parser/key.rs
+++ b/src/parser/key.rs
@@ -17,7 +17,7 @@ parse!(key() -> Vec1<Key>, {
             simple_key(),
             ws(),
         )).map(|(pre, (raw, key), suffix)| {
-            Key::new_unchecked(Repr::new_unchecked(raw), key, Decor::new(pre, suffix))
+            Key::new_unchecked(Repr::new_unchecked(raw), key).with_decor(Decor::new(pre, suffix))
         }),
         char(DOT_SEP)
     ).map(|k| Vec1::try_from_vec(k).expect("parser should guarantee this"))

--- a/src/table.rs
+++ b/src/table.rs
@@ -531,10 +531,7 @@ impl<'a> VacantEntry<'a> {
     /// Sets the value of the entry with the VacantEntry's key,
     /// and returns a mutable reference to it
     pub fn insert(self, value: Item) -> &'a mut Item {
-        let key = self
-            .key
-            .cloned()
-            .unwrap_or_else(|| Key::with_key(self.key()));
+        let key = self.key.cloned().unwrap_or_else(|| Key::new(self.key()));
         &mut self.entry.insert(TableKeyValue::new(key, value)).value
     }
 }


### PR DESCRIPTION
- There wasn't a way to make a key in the public API
- It can be nice to have option parameters to `new` without just the
  `&mut` functions (this came from work on value positions)
- With all of the changes to using `Key`, `Key::into_repr` isn't needed
  anymore