### PR TITLE
fix: Report errors when mixing std and dotted tables

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -502,9 +502,15 @@ key = "value"
         ];
         for document in &documents {
             let doc = TomlParser::parse(document);
-
-            assert!(doc.is_ok());
-            let doc = doc.unwrap();
+            let doc = match doc {
+                Ok(doc) => doc,
+                Err(err) => {
+                    panic!(
+                        "Parse error: {}\nFailed to parse:\n```\n{}\n```",
+                        err, document
+                    )
+                }
+            };
 
             dbg!(doc.to_string());
             dbg!(document);

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -131,8 +131,6 @@ impl TomlParser {
                 match entry.into_mut() {
                     // if [a.b.c] header preceded [a.b]
                     Item::Table(ref mut t) if t.implicit => {
-                        debug_assert!(t.values_len() == 0);
-
                         t.decor = decor;
                         t.position = Some(self.current_table_position);
                         t.set_implicit(false);

--- a/src/table.rs
+++ b/src/table.rs
@@ -80,13 +80,6 @@ impl Table {
         self.items.iter().filter(|i| !(i.1).value.is_none()).count()
     }
 
-    /// Returns the number of key/value pairs in the table.
-    ///
-    /// NOTE: Not accurate for dotted keys, see `get_values`
-    pub(crate) fn values_len(&self) -> usize {
-        self.items.iter().filter(|i| (i.1).value.is_value()).count()
-    }
-
     /// Returns true iff the table is empty.
     pub fn is_empty(&self) -> bool {
         self.len() == 0

--- a/tests/fixtures/invalid/duplicate-key-dotted-into-std.toml
+++ b/tests/fixtures/invalid/duplicate-key-dotted-into-std.toml
@@ -1,0 +1,6 @@
+[fruit.apple]
+size = "small"
+
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true

--- a/tests/fixtures/invalid/duplicate-key-std-into-dotted.toml
+++ b/tests/fixtures/invalid/duplicate-key-std-into-dotted.toml
@@ -1,0 +1,6 @@
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+[fruit.apple]
+size = "small"

--- a/tests/test_invalid.rs
+++ b/tests/test_invalid.rs
@@ -56,6 +56,16 @@ t!(
     "fixtures/invalid/duplicate-tables.toml"
 );
 t!(
+    test_duplicate_key_std_into_dotted,
+    "Duplicate key",
+    "fixtures/invalid/duplicate-key-std-into-dotted.toml"
+);
+t!(
+    test_duplicate_key_dotted_into_std,
+    "Duplicate key",
+    "fixtures/invalid/duplicate-key-dotted-into-std.toml"
+);
+t!(
     test_empty_implicit_table,
     "While parsing a Table Header",
     "fixtures/invalid/empty-implicit-table.toml"


### PR DESCRIPTION
This is incomplete.  To be thorough, we'd need to check this as we descend the path each time.  However, this was quick, clear, and covers probably the majority of cases.

I don't think its possible to mimic this error case with inline tables because they'd automatically be duplicate keys.

This is a part of #91