### PR TITLE
fix: Ensure floats stay as floats

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -46,13 +46,7 @@ impl Display for Value {
         match *self {
             Value::String(ref repr) => write!(f, "{}", repr),
             Value::Integer(ref repr) => write!(f, "{}", repr),
-            Value::Float(ref repr) => {
-                if repr.value().is_nan() {
-                    write!(f, "{}", repr.decor.display(&"nan", DEFAULT_VALUE_DECOR))
-                } else {
-                    write!(f, "{}", repr)
-                }
-            }
+            Value::Float(ref repr) => write!(f, "{}", repr),
             Value::Boolean(ref repr) => write!(f, "{}", repr),
             Value::OffsetDateTime(ref repr) => write!(f, "{}", repr),
             Value::LocalDateTime(ref repr) => write!(f, "{}", repr),

--- a/src/value.rs
+++ b/src/value.rs
@@ -458,7 +458,14 @@ impl From<i64> for Value {
 
 impl From<f64> for Value {
     fn from(f: f64) -> Self {
-        Value::Float(Formatted::new(f, Repr::new_unchecked(f.to_string())))
+        let repr = if f.is_nan() {
+            "nan".to_owned()
+        } else {
+            format!("{:e}", f)
+        };
+        let repr = Repr::new_unchecked(repr);
+
+        Value::Float(Formatted::new(f, repr))
     }
 }
 

--- a/tests/encoder_compliance.rs
+++ b/tests/encoder_compliance.rs
@@ -6,10 +6,6 @@ fn main() {
     let mut harness = toml_test_harness::EncoderHarness::new(encoder, decoder);
     harness
         .ignore([
-            "valid/comment/tricky.toml",
-            "valid/float/exponent.toml",
-            "valid/float/underscore.toml",
-            "valid/float/zero.toml",
             // Can't verify until decoder is fixed
             "valid/string/multiline-quotes.toml",
         ])

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -190,7 +190,7 @@ fn test_insert_values() {
 [tbl]
 key1 = "value1"
 key2 = 42
-key3 = 8.1415926
+key3 = 8.1415926e0
 
         [tbl.son]
 "#


### PR DESCRIPTION
Relying on Rust to format our floats was giving us "1000" which we then
read as an integer, failing tests.

This gives us a cheap-to-implement solution so we'll always preserve the
float-ness, even if it can be ugly.  We can iterate if this is a
problem.  I just don't expect many floats so I don't expect this to be a
problem.

While at it, this changed the nan issue (#169) to be fixed at the
source, at repr generation.