### PR TITLE
fix: Proper equality for easy::Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 easy = ["serde"]
 
 [dependencies]
-linked-hash-map = "0.5.2"
+indexmap = "1.7"
 combine = "4.5.2"
 vec1 = "1"
 itertools = "0.10"

--- a/src/easy/de/inline_table.rs
+++ b/src/easy/de/inline_table.rs
@@ -3,7 +3,7 @@ use serde::de::IntoDeserializer;
 use crate::easy::de::Error;
 
 pub(crate) struct InlineTableMapAccess {
-    iter: linked_hash_map::IntoIter<crate::repr::InternalString, crate::table::TableKeyValue>,
+    iter: indexmap::map::IntoIter<crate::repr::InternalString, crate::table::TableKeyValue>,
     value: Option<crate::Item>,
 }
 

--- a/src/easy/de/table.rs
+++ b/src/easy/de/table.rs
@@ -3,7 +3,7 @@ use serde::de::IntoDeserializer;
 use crate::easy::de::Error;
 
 pub(crate) struct TableMapAccess {
-    iter: linked_hash_map::IntoIter<crate::repr::InternalString, crate::table::TableKeyValue>,
+    iter: indexmap::map::IntoIter<crate::repr::InternalString, crate::table::TableKeyValue>,
     value: Option<crate::Item>,
 }
 

--- a/src/easy/map.rs
+++ b/src/easy/map.rs
@@ -14,7 +14,7 @@ use std::hash::Hash;
 use std::iter::FromIterator;
 use std::ops;
 
-use linked_hash_map::{self, LinkedHashMap};
+use indexmap::map::IndexMap;
 use serde::{de, ser};
 
 use crate::easy::value::Value;
@@ -24,7 +24,7 @@ pub struct Map<K, V> {
     map: MapImpl<K, V>,
 }
 
-type MapImpl<K, V> = LinkedHashMap<K, V>;
+type MapImpl<K, V> = IndexMap<K, V>;
 
 impl Map<String, Value> {
     /// Makes a new empty Map.
@@ -39,7 +39,7 @@ impl Map<String, Value> {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Map {
-            map: LinkedHashMap::with_capacity(capacity),
+            map: IndexMap::with_capacity(capacity),
         }
     }
 
@@ -120,7 +120,7 @@ impl Map<String, Value> {
     where
         S: Into<String>,
     {
-        use linked_hash_map::Entry as EntryImpl;
+        use indexmap::map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant }),
@@ -367,9 +367,9 @@ pub struct OccupiedEntry<'a> {
     occupied: OccupiedEntryImpl<'a>,
 }
 
-type VacantEntryImpl<'a> = linked_hash_map::VacantEntry<'a, String, Value>;
+type VacantEntryImpl<'a> = indexmap::map::VacantEntry<'a, String, Value>;
 
-type OccupiedEntryImpl<'a> = linked_hash_map::OccupiedEntry<'a, String, Value>;
+type OccupiedEntryImpl<'a> = indexmap::map::OccupiedEntry<'a, String, Value>;
 
 impl<'a> Entry<'a> {
     /// Returns a reference to this entry's key.
@@ -476,7 +476,7 @@ pub struct Iter<'a> {
     iter: IterImpl<'a>,
 }
 
-type IterImpl<'a> = linked_hash_map::Iter<'a, String, Value>;
+type IterImpl<'a> = indexmap::map::Iter<'a, String, Value>;
 
 delegate_iterator!((Iter<'a>) => (&'a String, &'a Value));
 
@@ -498,7 +498,7 @@ pub struct IterMut<'a> {
     iter: IterMutImpl<'a>,
 }
 
-type IterMutImpl<'a> = linked_hash_map::IterMut<'a, String, Value>;
+type IterMutImpl<'a> = indexmap::map::IterMut<'a, String, Value>;
 
 delegate_iterator!((IterMut<'a>) => (&'a String, &'a mut Value));
 
@@ -520,7 +520,7 @@ pub struct IntoIter {
     iter: IntoIterImpl,
 }
 
-type IntoIterImpl = linked_hash_map::IntoIter<String, Value>;
+type IntoIterImpl = indexmap::map::IntoIter<String, Value>;
 
 delegate_iterator!((IntoIter) => (String, Value));
 
@@ -531,7 +531,7 @@ pub struct Keys<'a> {
     iter: KeysImpl<'a>,
 }
 
-type KeysImpl<'a> = linked_hash_map::Keys<'a, String, Value>;
+type KeysImpl<'a> = indexmap::map::Keys<'a, String, Value>;
 
 delegate_iterator!((Keys<'a>) => &'a String);
 
@@ -542,6 +542,6 @@ pub struct Values<'a> {
     iter: ValuesImpl<'a>,
 }
 
-type ValuesImpl<'a> = linked_hash_map::Values<'a, String, Value>;
+type ValuesImpl<'a> = indexmap::map::Values<'a, String, Value>;
 
 delegate_iterator!((Values<'a>) => &'a Value);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "easy")]
 
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use toml_edit::easy::map::Map;
 use toml_edit::easy::Value;
@@ -177,39 +177,6 @@ fn inner_structs_with_options() {
 }
 
 #[test]
-#[should_panic] // Our equality is broken, see https://github.com/ordian/toml_edit/issues/194
-fn hashmap() {
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-    struct Foo {
-        set: HashSet<char>,
-        map: BTreeMap<String, isize>,
-    }
-
-    equivalent! {
-        Foo {
-            map: {
-                let mut m = BTreeMap::new();
-                m.insert("foo".to_string(), 10);
-                m.insert("bar".to_string(), 4);
-                m
-            },
-            set: {
-                let mut s = HashSet::new();
-                s.insert('a');
-                s
-            },
-        },
-        Table(map! {
-            map: Table(map! {
-                foo: Integer(10),
-                bar: Integer(4)
-            }),
-            set: Array(vec![Value::String("a".to_string())])
-        }),
-    }
-}
-
-#[test]
 fn table_array() {
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Foo {
@@ -334,131 +301,6 @@ fn parse_enum_string() {
         Table(map! { a: Value::String("desc".to_string()) }),
     }
 }
-
-// #[test]
-// fn unused_fields() {
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Foo { a: isize }
-//
-//     let v = Foo { a: 2 };
-//     let mut d = Decoder::new(Table(map! {
-//         a, Integer(2),
-//         b, Integer(5)
-//     }));
-//     assert_eq!(v, t!(Deserialize::deserialize(&mut d)));
-//
-//     assert_eq!(d.toml, Some(Table(map! {
-//         b, Integer(5)
-//     })));
-// }
-//
-// #[test]
-// fn unused_fields2() {
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Foo { a: Bar }
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Bar { a: isize }
-//
-//     let v = Foo { a: Bar { a: 2 } };
-//     let mut d = Decoder::new(Table(map! {
-//         a, Table(map! {
-//             a, Integer(2),
-//             b, Integer(5)
-//         })
-//     }));
-//     assert_eq!(v, t!(Deserialize::deserialize(&mut d)));
-//
-//     assert_eq!(d.toml, Some(Table(map! {
-//         a, Table(map! {
-//             b, Integer(5)
-//         })
-//     })));
-// }
-//
-// #[test]
-// fn unused_fields3() {
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Foo { a: Bar }
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Bar { a: isize }
-//
-//     let v = Foo { a: Bar { a: 2 } };
-//     let mut d = Decoder::new(Table(map! {
-//         a, Table(map! {
-//             a, Integer(2)
-//         })
-//     }));
-//     assert_eq!(v, t!(Deserialize::deserialize(&mut d)));
-//
-//     assert_eq!(d.toml, None);
-// }
-//
-// #[test]
-// fn unused_fields4() {
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Foo { a: BTreeMap<String, String> }
-//
-//     let v = Foo { a: map! { a, "foo".to_string() } };
-//     let mut d = Decoder::new(Table(map! {
-//         a, Table(map! {
-//             a, Value::String("foo".to_string())
-//         })
-//     }));
-//     assert_eq!(v, t!(Deserialize::deserialize(&mut d)));
-//
-//     assert_eq!(d.toml, None);
-// }
-//
-// #[test]
-// fn unused_fields5() {
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Foo { a: Vec<String> }
-//
-//     let v = Foo { a: vec!["a".to_string()] };
-//     let mut d = Decoder::new(Table(map! {
-//         a, Array(vec![Value::String("a".to_string())])
-//     }));
-//     assert_eq!(v, t!(Deserialize::deserialize(&mut d)));
-//
-//     assert_eq!(d.toml, None);
-// }
-//
-// #[test]
-// fn unused_fields6() {
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Foo { a: Option<Vec<String>> }
-//
-//     let v = Foo { a: Some(vec![]) };
-//     let mut d = Decoder::new(Table(map! {
-//         a, Array(vec![])
-//     }));
-//     assert_eq!(v, t!(Deserialize::deserialize(&mut d)));
-//
-//     assert_eq!(d.toml, None);
-// }
-//
-// #[test]
-// fn unused_fields7() {
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Foo { a: Vec<Bar> }
-//     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-//     struct Bar { a: isize }
-//
-//     let v = Foo { a: vec![Bar { a: 1 }] };
-//     let mut d = Decoder::new(Table(map! {
-//         a, Array(vec![Table(map! {
-//             a, Integer(1),
-//             b, Integer(2)
-//         })])
-//     }));
-//     assert_eq!(v, t!(Deserialize::deserialize(&mut d)));
-//
-//     assert_eq!(d.toml, Some(Table(map! {
-//         a, Array(vec![Table(map! {
-//             b, Integer(2)
-//         })])
-//     })));
-// }
 
 #[test]
 fn empty_arrays() {


### PR DESCRIPTION
`LinkedHashMap`s equality checked order when we don't want it to.  It
also isn't maintained.  So we're switching to `IndexMap`

Unfortunately, there are other ordering issues in the relevant test that
makes it hard to get right, so went ahead and removed it.

Unfortunately, I didn't see any change in performance.

Fixes #194