### PR TITLE
feat: Add table-like mutations

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -212,6 +212,15 @@ impl Item {
             .or_else(|| self.as_inline_table().map(|t| t as &dyn TableLike))
     }
 
+    /// Casts `self` to either a table or an inline table.
+    pub fn as_table_like_mut(&mut self) -> Option<&mut dyn TableLike> {
+        match self {
+            Item::Table(t) => Some(t as &mut dyn TableLike),
+            Item::Value(Value::InlineTable(t)) => Some(t as &mut dyn TableLike),
+            _ => None,
+        }
+    }
+
     /// Returns true iff `self` is either a table, or an inline table.
     pub fn is_table_like(&self) -> bool {
         self.as_table_like().is_some()

--- a/src/table.rs
+++ b/src/table.rs
@@ -394,6 +394,8 @@ pub type IterMut<'a> = Box<dyn Iterator<Item = (&'a str, &'a mut Item)> + 'a>;
 pub trait TableLike {
     /// Returns an iterator over key/value pairs.
     fn iter(&self) -> Iter<'_>;
+    /// Returns an mutable iterator over all key/value pairs, including empty.
+    fn iter_mut(&mut self) -> IterMut<'_>;
     /// Returns the number of nonempty items.
     fn len(&self) -> usize {
         self.iter().filter(|&(_, v)| !v.is_none()).count()
@@ -406,6 +408,12 @@ pub trait TableLike {
     fn get<'s>(&'s self, key: &str) -> Option<&'s Item>;
     /// Returns an optional mutable reference to an item given the key.
     fn get_mut<'s>(&'s mut self, key: &str) -> Option<&'s mut Item>;
+    /// Returns true iff the table contains an item with the given key.
+    fn contains_key(&self, key: &str) -> bool;
+    /// Inserts a key-value pair into the map.
+    fn insert(&mut self, key: &str, value: Item) -> Option<Item>;
+    /// Removes an item given the key.
+    fn remove(&mut self, key: &str) -> Option<Item>;
 
     /// Get key/values for values that are visually children of this table
     ///
@@ -426,9 +434,11 @@ pub trait TableLike {
 }
 
 impl TableLike for Table {
-    /// Returns an iterator over all subitems, including `Item::None`.
     fn iter(&self) -> Iter<'_> {
         self.iter()
+    }
+    fn iter_mut(&mut self) -> IterMut<'_> {
+        self.iter_mut()
     }
     fn get<'s>(&'s self, key: &str) -> Option<&'s Item> {
         self.get(key)
@@ -436,6 +446,16 @@ impl TableLike for Table {
     fn get_mut<'s>(&'s mut self, key: &str) -> Option<&'s mut Item> {
         self.get_mut(key)
     }
+    fn contains_key(&self, key: &str) -> bool {
+        self.contains_key(key)
+    }
+    fn insert(&mut self, key: &str, value: Item) -> Option<Item> {
+        self.insert(key, value)
+    }
+    fn remove(&mut self, key: &str) -> Option<Item> {
+        self.remove(key)
+    }
+
     fn get_values(&self) -> Vec<(Vec<&Key>, &Value)> {
         self.get_values()
     }


### PR DESCRIPTION
- `insert` is made safe due to `into_value`
- `iter_mut` is as safe as existing indexing and `get_mut`
- others, like `remove`, are universal