### PR TITLE
perf: Skip table lookup per entry

### DIFF
--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -24,7 +24,6 @@ impl TomlError {
         )
     }
 
-    #[cfg(feature = "easy")]
     pub(crate) fn custom(message: String) -> Self {
         Self { message }
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -38,14 +38,6 @@ impl Table {
         }
     }
 
-    pub(crate) fn with_decor_and_pos(decor: Decor, position: Option<usize>) -> Self {
-        Self {
-            decor,
-            position,
-            ..Default::default()
-        }
-    }
-
     /// Convert to an inline array
     pub fn into_inline_table(mut self) -> InlineTable {
         for (_, kv) in self.items.iter_mut() {


### PR DESCRIPTION
Before, for every key-value pair, we'd find the table and insert.  Now,
we store off the table as we come across each header and insert directly
into it (ignoring the lookups for dotted keys).

I was hoping this would drop us from N lookups to 1 lookup per table but
we need 2 lookups per table to ensure proper error reporting.