### PR TITLE
fix: Sane default array decor

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -304,6 +304,12 @@ impl Array {
     }
 }
 
+impl std::fmt::Display for Array {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        crate::encode::Encode::encode(self, f, ("", ""))
+    }
+}
+
 impl<V: Into<Value>> Extend<V> for Array {
     fn extend<T: IntoIterator<Item = V>>(&mut self, iter: T) {
         for value in iter {

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -270,6 +270,12 @@ impl InlineTable {
     }
 }
 
+impl std::fmt::Display for InlineTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        crate::encode::Encode::encode(self, f, ("", ""))
+    }
+}
+
 impl<K: Into<Key>, V: Into<Value>> Extend<(K, V)> for InlineTable {
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         for (key, value) in iter {

--- a/src/key.rs
+++ b/src/key.rs
@@ -99,6 +99,12 @@ impl Key {
     }
 }
 
+impl std::fmt::Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        crate::encode::Encode::encode(self, f, ("", ""))
+    }
+}
+
 impl FromStr for Key {
     type Err = parser::TomlError;
 

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -62,6 +62,15 @@ where
     }
 }
 
+impl<T> std::fmt::Display for Formatted<T>
+where
+    T: ValueRepr,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        crate::encode::Encode::encode(self, f, ("", ""))
+    }
+}
+
 pub trait ValueRepr: crate::private::Sealed {
     /// The TOML representation of the value
     fn to_repr(&self) -> Repr;
@@ -83,6 +92,12 @@ impl Repr {
     /// Access the underlying value
     pub fn as_raw(&self) -> &str {
         &self.raw_value
+    }
+}
+
+impl std::fmt::Display for Repr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_raw().fmt(f)
     }
 }
 
@@ -119,27 +134,4 @@ impl Decor {
     pub fn suffix(&self) -> Option<&str> {
         self.suffix.as_deref()
     }
-
-    /// Render a value with its decor
-    pub(crate) fn display<'d, D: std::fmt::Display + std::fmt::Debug>(
-        &'d self,
-        inner: &'d D,
-        default: (&'static str, &'static str),
-    ) -> DecorDisplay<'d, D> {
-        DecorDisplay {
-            inner,
-            decor: self,
-            default,
-        }
-    }
-}
-
-/// Render a prefix and suffix,
-///
-/// Including comments, whitespaces and newlines.
-#[derive(Debug)]
-pub(crate) struct DecorDisplay<'d, D> {
-    pub(crate) inner: &'d D,
-    pub(crate) decor: &'d Decor,
-    pub(crate) default: (&'static str, &'static str),
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -295,6 +295,21 @@ impl Table {
     }
 }
 
+impl std::fmt::Display for Table {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use crate::encode::Encode;
+        let children = self.get_values();
+        // print table body
+        for (key_path, value) in children {
+            key_path.as_slice().encode(f, DEFAULT_KEY_DECOR)?;
+            write!(f, "=")?;
+            value.encode(f, DEFAULT_VALUE_DECOR)?;
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
+
 impl<K: Into<Key>, V: Into<Value>> Extend<(K, V)> for Table {
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         for (key, value) in iter {

--- a/src/value.rs
+++ b/src/value.rs
@@ -192,7 +192,7 @@ impl Value {
     /// # Example
     /// ```rust
     /// let mut v = toml_edit::Value::from(42);
-    /// assert_eq!(&v.to_string(), " 42");
+    /// assert_eq!(&v.to_string(), "42");
     /// let d = v.decorated(" ", " ");
     /// assert_eq!(&d.to_string(), " 42 ");
     /// ```
@@ -323,9 +323,27 @@ impl<K: Into<Key>, V: Into<Value>> FromIterator<(K, V)> for Value {
     }
 }
 
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        crate::encode::Encode::encode(self, f, ("", ""))
+    }
+}
+
 // `key1 = value1`
 pub(crate) const DEFAULT_VALUE_DECOR: (&str, &str) = (" ", "");
 // `{ key = value }`
 pub(crate) const DEFAULT_TRAILING_VALUE_DECOR: (&str, &str) = (" ", " ");
 // `[value1, value2]`
 pub(crate) const DEFAULT_LEADING_VALUE_DECOR: (&str, &str) = ("", "");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_iter_formatting() {
+        let features = vec!["node".to_owned(), "mouth".to_owned()];
+        let features: Value = features.iter().cloned().collect();
+        assert_eq!(features.to_string(), r#"["node", "mouth"]"#);
+    }
+}


### PR DESCRIPTION
When porting cargo-edit to toml_edit 0.3, I found the default array
formatting is off.  This is because our `Display` doesn't have
knowledge of its context.  Generally, the caller knows better what the
default decode should be.

This adds a new trait for encoding which allows the caller to pass in
the needed context.