### PR TITLE
refactor!: Make InternalString a newtype

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -1,9 +1,9 @@
 use std::iter::FromIterator;
 use std::mem;
 
-use crate::repr::{Decor, InternalString};
+use crate::repr::Decor;
 use crate::value::{DEFAULT_LEADING_VALUE_DECOR, DEFAULT_VALUE_DECOR};
-use crate::{Item, Value};
+use crate::{InternalString, Item, Value};
 
 /// Type representing a TOML array,
 /// payload of the `Value::Array` variant's value
@@ -68,7 +68,7 @@ impl Array {
 
     /// Set whitespace after last element
     pub fn set_trailing(&mut self, trailing: &str) {
-        self.trailing = trailing.to_owned();
+        self.trailing = InternalString::from(trailing);
     }
 
     /// Whitespace after last element

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,9 +1,8 @@
 use std::str::FromStr;
 
 use crate::parser;
-use crate::repr::InternalString;
 use crate::table::Iter;
-use crate::{Item, Table};
+use crate::{InternalString, Item, Table};
 
 /// Type representing a TOML document
 #[derive(Debug, Clone)]
@@ -42,7 +41,7 @@ impl Document {
 
     /// Set whitespace after last element
     pub fn set_trailing(&mut self, trailing: &str) {
-        self.trailing = trailing.to_owned();
+        self.trailing = InternalString::from(trailing);
     }
 
     /// Whitespace after last element

--- a/src/easy/de/inline_table.rs
+++ b/src/easy/de/inline_table.rs
@@ -3,7 +3,7 @@ use serde::de::IntoDeserializer;
 use crate::easy::de::Error;
 
 pub(crate) struct InlineTableMapAccess {
-    iter: indexmap::map::IntoIter<crate::repr::InternalString, crate::table::TableKeyValue>,
+    iter: indexmap::map::IntoIter<crate::InternalString, crate::table::TableKeyValue>,
     value: Option<crate::Item>,
 }
 

--- a/src/easy/de/table.rs
+++ b/src/easy/de/table.rs
@@ -3,7 +3,7 @@ use serde::de::IntoDeserializer;
 use crate::easy::de::Error;
 
 pub(crate) struct TableMapAccess {
-    iter: indexmap::map::IntoIter<crate::repr::InternalString, crate::table::TableKeyValue>,
+    iter: indexmap::map::IntoIter<crate::InternalString, crate::table::TableKeyValue>,
     value: Option<crate::Item>,
 }
 

--- a/src/easy/ser/key.rs
+++ b/src/easy/ser/key.rs
@@ -1,90 +1,92 @@
+use crate::InternalString;
+
 use super::{Error, ErrorKind};
 
 pub(crate) struct KeySerializer;
 
 impl serde::ser::Serializer for KeySerializer {
-    type Ok = String;
+    type Ok = InternalString;
     type Error = Error;
-    type SerializeSeq = serde::ser::Impossible<String, Error>;
-    type SerializeTuple = serde::ser::Impossible<String, Error>;
-    type SerializeTupleStruct = serde::ser::Impossible<String, Error>;
-    type SerializeTupleVariant = serde::ser::Impossible<String, Error>;
-    type SerializeMap = serde::ser::Impossible<String, Error>;
-    type SerializeStruct = serde::ser::Impossible<String, Error>;
-    type SerializeStructVariant = serde::ser::Impossible<String, Error>;
+    type SerializeSeq = serde::ser::Impossible<InternalString, Error>;
+    type SerializeTuple = serde::ser::Impossible<InternalString, Error>;
+    type SerializeTupleStruct = serde::ser::Impossible<InternalString, Error>;
+    type SerializeTupleVariant = serde::ser::Impossible<InternalString, Error>;
+    type SerializeMap = serde::ser::Impossible<InternalString, Error>;
+    type SerializeStruct = serde::ser::Impossible<InternalString, Error>;
+    type SerializeStructVariant = serde::ser::Impossible<InternalString, Error>;
 
-    fn serialize_bool(self, _v: bool) -> Result<String, Self::Error> {
+    fn serialize_bool(self, _v: bool) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_i8(self, _v: i8) -> Result<String, Self::Error> {
+    fn serialize_i8(self, _v: i8) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_i16(self, _v: i16) -> Result<String, Self::Error> {
+    fn serialize_i16(self, _v: i16) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_i32(self, _v: i32) -> Result<String, Self::Error> {
+    fn serialize_i32(self, _v: i32) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_i64(self, _v: i64) -> Result<String, Self::Error> {
+    fn serialize_i64(self, _v: i64) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_u8(self, _v: u8) -> Result<String, Self::Error> {
+    fn serialize_u8(self, _v: u8) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_u16(self, _v: u16) -> Result<String, Self::Error> {
+    fn serialize_u16(self, _v: u16) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_u32(self, _v: u32) -> Result<String, Self::Error> {
+    fn serialize_u32(self, _v: u32) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_u64(self, _v: u64) -> Result<String, Self::Error> {
+    fn serialize_u64(self, _v: u64) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_f32(self, _v: f32) -> Result<String, Self::Error> {
+    fn serialize_f32(self, _v: f32) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_f64(self, _v: f64) -> Result<String, Self::Error> {
+    fn serialize_f64(self, _v: f64) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_char(self, _v: char) -> Result<String, Self::Error> {
+    fn serialize_char(self, _v: char) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_str(self, value: &str) -> Result<String, Self::Error> {
-        Ok(value.to_string())
+    fn serialize_str(self, value: &str) -> Result<InternalString, Self::Error> {
+        Ok(InternalString::from(value))
     }
 
-    fn serialize_bytes(self, _value: &[u8]) -> Result<String, Self::Error> {
+    fn serialize_bytes(self, _value: &[u8]) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_none(self) -> Result<String, Self::Error> {
+    fn serialize_none(self) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<String, Self::Error>
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<InternalString, Self::Error>
     where
         T: serde::ser::Serialize,
     {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_unit(self) -> Result<String, Self::Error> {
+    fn serialize_unit(self) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<String, Self::Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
@@ -93,7 +95,7 @@ impl serde::ser::Serializer for KeySerializer {
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-    ) -> Result<String, Self::Error> {
+    ) -> Result<InternalString, Self::Error> {
         Err(ErrorKind::KeyNotString.into())
     }
 
@@ -101,7 +103,7 @@ impl serde::ser::Serializer for KeySerializer {
         self,
         _name: &'static str,
         value: &T,
-    ) -> Result<String, Self::Error>
+    ) -> Result<InternalString, Self::Error>
     where
         T: serde::ser::Serialize,
     {
@@ -114,7 +116,7 @@ impl serde::ser::Serializer for KeySerializer {
         _variant_index: u32,
         _variant: &'static str,
         _value: &T,
-    ) -> Result<String, Self::Error>
+    ) -> Result<InternalString, Self::Error>
     where
         T: serde::ser::Serialize,
     {

--- a/src/easy/ser/table.rs
+++ b/src/easy/ser/table.rs
@@ -206,7 +206,7 @@ impl serde::ser::SerializeStruct for SerializeItemTable {
 
 struct SerializeKeyValuePairs {
     items: crate::table::KeyValuePairs,
-    key: Option<String>,
+    key: Option<crate::InternalString>,
 }
 
 impl SerializeKeyValuePairs {
@@ -288,7 +288,7 @@ impl serde::ser::SerializeStruct for SerializeKeyValuePairs {
         };
         if !item.is_none() {
             let kv = crate::table::TableKeyValue::new(crate::Key::new(key), item);
-            self.items.insert(key.to_owned(), kv);
+            self.items.insert(crate::InternalString::from(key), kv);
         }
         Ok(())
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,7 @@ use std::ops;
 use crate::document::Document;
 use crate::key::Key;
 use crate::table::TableKeyValue;
-use crate::{value, InlineTable, Item, Table, Value};
+use crate::{value, InlineTable, InternalString, Item, Table, Value};
 
 // copied from
 // https://github.com/serde-rs/json/blob/master/src/value/index.rs
@@ -60,7 +60,7 @@ impl Index for str {
         if let Item::None = *v {
             let mut t = InlineTable::default();
             t.items.insert(
-                key.get().to_owned(),
+                InternalString::from(key.get()),
                 TableKeyValue::new(key.clone(), Item::None),
             );
             *v = value(Value::InlineTable(t));
@@ -72,7 +72,7 @@ impl Index for str {
                     .as_inline_table_mut()
                     .unwrap()
                     .items
-                    .entry(key.get().to_owned())
+                    .entry(InternalString::from(key.get()))
                     .or_insert(TableKeyValue::new(key, Item::None))
                     .value
             }

--- a/src/internal_string.rs
+++ b/src/internal_string.rs
@@ -1,0 +1,165 @@
+use std::borrow::Borrow;
+use std::str::FromStr;
+
+/// Opaque string storage internal to `toml_edit`
+#[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InternalString(String);
+
+impl InternalString {
+    /// Create an empty string
+    pub fn new() -> Self {
+        InternalString(String::new())
+    }
+
+    /// Access the underlying string
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl std::ops::Deref for InternalString {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for InternalString {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for InternalString {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<&str> for InternalString {
+    #[inline]
+    fn from(s: &str) -> Self {
+        String::from(s).into()
+    }
+}
+
+impl From<String> for InternalString {
+    #[inline]
+    fn from(s: String) -> Self {
+        InternalString(s)
+    }
+}
+
+impl From<&String> for InternalString {
+    #[inline]
+    fn from(s: &String) -> Self {
+        String::from(s).into()
+    }
+}
+
+impl From<&InternalString> for InternalString {
+    #[inline]
+    fn from(s: &InternalString) -> Self {
+        s.clone()
+    }
+}
+
+impl From<Box<str>> for InternalString {
+    #[inline]
+    fn from(s: Box<str>) -> Self {
+        String::from(s).into()
+    }
+}
+
+impl FromStr for InternalString {
+    type Err = core::convert::Infallible;
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from(s))
+    }
+}
+
+impl std::fmt::Display for InternalString {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for InternalString {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for InternalString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_string(StringVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+struct StringVisitor;
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Visitor<'de> for StringVisitor {
+    type Value = InternalString;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(InternalString::from(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(InternalString::from(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match std::str::from_utf8(v) {
+            Ok(s) => Ok(InternalString::from(s)),
+            Err(_) => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Bytes(v),
+                &self,
+            )),
+        }
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match String::from_utf8(v) {
+            Ok(s) => Ok(InternalString::from(s)),
+            Err(e) => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Bytes(&e.into_bytes()),
+                &self,
+            )),
+        }
+    }
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -6,7 +6,8 @@ use combine::stream::position::Stream;
 use crate::encode::{to_string_repr, StringStyle};
 use crate::parser;
 use crate::parser::is_unquoted_char;
-use crate::repr::{Decor, InternalString, Repr};
+use crate::repr::{Decor, Repr};
+use crate::InternalString;
 
 /// Key as part of a Key/Value Pair or a table header.
 ///
@@ -39,9 +40,9 @@ pub struct Key {
 
 impl Key {
     /// Create a new table key
-    pub fn new(key: impl AsRef<str>) -> Self {
+    pub fn new(key: impl Into<InternalString>) -> Self {
         Self {
-            key: key.as_ref().into(),
+            key: key.into(),
             repr: None,
             decor: Default::default(),
         }
@@ -142,6 +143,12 @@ impl<'b> From<&'b String> for Key {
 
 impl From<String> for Key {
     fn from(s: String) -> Self {
+        Key::new(s)
+    }
+}
+
+impl From<InternalString> for Key {
+    fn from(s: InternalString) -> Self {
         Key::new(s)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ mod document;
 mod encode;
 mod index;
 mod inline_table;
+mod internal_string;
 mod item;
 mod key;
 mod parser;
@@ -89,6 +90,7 @@ pub use crate::inline_table::{
     InlineEntry, InlineOccupiedEntry, InlineTable, InlineTableIntoIter, InlineTableIter,
     InlineTableIterMut, InlineVacantEntry,
 };
+pub use crate::internal_string::InternalString;
 pub use crate::item::{array, table, value, Item};
 pub use crate::key::Key;
 pub use crate::parser::TomlError;

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -4,9 +4,8 @@ use crate::parser::key::key;
 use crate::parser::table::duplicate_key;
 use crate::parser::trivia::ws;
 use crate::parser::value::value;
-use crate::repr::InternalString;
 use crate::table::TableKeyValue;
-use crate::{InlineTable, Item, Value};
+use crate::{InlineTable, InternalString, Item, Value};
 use combine::parser::char::char;
 use combine::stream::RangeStream;
 use combine::*;
@@ -30,11 +29,11 @@ fn table_from_pairs(
         let table = descend_path(&mut root, &path, 0)?;
         if table.contains_key(kv.key.get()) {
             return Err(CustomError::DuplicateKey {
-                key: kv.key.into(),
+                key: kv.key.get().into(),
                 table: "inline".into(),
             });
         }
-        table.items.insert(kv.key.get().to_owned(), kv);
+        table.items.insert(kv.key.clone().into(), kv);
     }
     Ok(root)
 }

--- a/src/parser/key.rs
+++ b/src/parser/key.rs
@@ -1,7 +1,8 @@
 use crate::key::Key;
 use crate::parser::strings::{basic_string, literal_string};
 use crate::parser::trivia::ws;
-use crate::repr::{Decor, InternalString, Repr};
+use crate::repr::{Decor, Repr};
+use crate::InternalString;
 use combine::parser::char::char;
 use combine::parser::range::{recognize_with_value, take_while1};
 use combine::stream::RangeStream;
@@ -44,7 +45,7 @@ pub(crate) fn is_unquoted_char(c: char) -> bool {
 // quoted-key = basic-string / literal-string
 parse!(quoted_key() -> InternalString, {
     choice((
-        basic_string(),
+        basic_string().map(|s: String| s.into()),
         literal_string().map(|s: &'a str| s.into()),
     ))
 });

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -29,6 +29,7 @@ use vec1::Vec1;
 
 pub(crate) struct TomlParser {
     document: Box<Document>,
+    trailing: String,
     current_table_position: usize,
     current_table: Table,
     current_is_array: bool,
@@ -140,6 +141,7 @@ impl Default for TomlParser {
     fn default() -> Self {
         Self {
             document: Box::new(Document::new()),
+            trailing: String::new(),
             current_table_position: 0,
             current_table: Table::new(),
             current_is_array: false,
@@ -524,7 +526,7 @@ trimmed in raw strings.
             let parsed = key::simple_key().easy_parse(Stream::new(input));
             assert!(parsed.is_ok());
             let ((.., k), rest) = parsed.unwrap();
-            assert_eq!(k, expected);
+            assert_eq!(k.as_str(), expected);
             assert_eq!(rest.input.len(), 0);
         }
     }

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -1,6 +1,5 @@
 use crate::parser::errors::CustomError;
 use crate::parser::trivia::{is_non_ascii, is_wschar, newline, ws, ws_newlines};
-use crate::repr::InternalString;
 use combine::error::{Commit, Info};
 use combine::parser::char::char;
 use combine::parser::range::{range, take, take_while, take_while1};
@@ -12,7 +11,7 @@ use std::char;
 // ;; String
 
 // string = ml-basic-string / basic-string / ml-literal-string / literal-string
-parse!(string() -> InternalString, {
+parse!(string() -> String, {
     choice((
         ml_basic_string(),
         basic_string(),
@@ -24,7 +23,7 @@ parse!(string() -> InternalString, {
 // ;; Basic String
 
 // basic-string = quotation-mark *basic-char quotation-mark
-parse!(basic_string() -> InternalString, {
+parse!(basic_string() -> String, {
     between(
         char(QUOTATION_MARK), char(QUOTATION_MARK),
         many(basic_chars())
@@ -102,7 +101,7 @@ parse!(hexescape(n: usize) -> char, {
 // ;; Multiline Basic String
 
 // ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
-parse!(ml_basic_string() -> InternalString, {
+parse!(ml_basic_string() -> String, {
     between(range(ML_BASIC_STRING_DELIM),
             range(ML_BASIC_STRING_DELIM),
             ml_basic_body())
@@ -113,7 +112,7 @@ parse!(ml_basic_string() -> InternalString, {
 const ML_BASIC_STRING_DELIM: &str = "\"\"\"";
 
 // ml-basic-body = *( ( escape ws-newline ) / ml-basic-char / newline )
-parse!(ml_basic_body() -> InternalString, {
+parse!(ml_basic_body() -> String, {
     //  A newline immediately following the opening delimiter will be trimmed.
     optional(newline())
         .skip(try_eat_escaped_newline())
@@ -187,7 +186,7 @@ fn is_literal_char(c: char) -> bool {
 // ;; Multiline Literal String
 
 // ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
-parse!(ml_literal_string() -> InternalString, {
+parse!(ml_literal_string() -> String, {
     between(range(ML_LITERAL_STRING_DELIM),
             range(ML_LITERAL_STRING_DELIM),
             ml_literal_body())
@@ -198,7 +197,7 @@ parse!(ml_literal_string() -> InternalString, {
 const ML_LITERAL_STRING_DELIM: &str = "'''";
 
 // ml-literal-body = *( ml-literal-char / newline )
-parse!(ml_literal_body() -> InternalString, {
+parse!(ml_literal_body() -> String, {
     //  A newline immediately following the opening delimiter will be trimmed.
     optional(newline())
         .with(

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -120,7 +120,7 @@ impl TomlParser {
         debug_assert!(!path.is_empty());
 
         self.finalize_table()?;
-        let leading = mem::take(&mut self.document.trailing);
+        let leading = mem::take(&mut self.trailing);
         self.start_table(path, Decor::new(leading, trailing))?;
 
         Ok(())
@@ -130,7 +130,7 @@ impl TomlParser {
         debug_assert!(!path.is_empty());
 
         self.finalize_table()?;
-        let leading = mem::take(&mut self.document.trailing);
+        let leading = mem::take(&mut self.trailing);
         self.start_aray_table(path, Decor::new(leading, trailing))?;
 
         Ok(())

--- a/src/repr.rs
+++ b/src/repr.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-pub(crate) type InternalString = String;
+use crate::InternalString;
 
 /// A value together with its `to_string` representation,
 /// including surrounding it whitespaces and comments.
@@ -112,7 +112,7 @@ pub struct Decor {
 
 impl Decor {
     /// Creates a new decor from the given prefix and suffix.
-    pub fn new(prefix: impl Into<String>, suffix: impl Into<String>) -> Self {
+    pub fn new(prefix: impl Into<InternalString>, suffix: impl Into<InternalString>) -> Self {
         Self {
             prefix: Some(prefix.into()),
             suffix: Some(suffix.into()),

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,8 +6,8 @@ use combine::stream::position::Stream;
 use crate::datetime::*;
 use crate::key::Key;
 use crate::parser;
-use crate::repr::{Decor, Formatted, InternalString};
-use crate::{Array, InlineTable};
+use crate::repr::{Decor, Formatted};
+use crate::{Array, InlineTable, InternalString};
 
 /// Representation of a TOML Value (as part of a Key/Value Pair).
 #[derive(Debug, Clone)]
@@ -236,20 +236,31 @@ impl<'b> From<&'b Value> for Value {
 
 impl<'b> From<&'b str> for Value {
     fn from(s: &'b str) -> Self {
-        let value = s.to_owned();
-        Value::String(Formatted::new(value))
+        s.to_owned().into()
     }
 }
 
 impl<'b> From<&'b String> for Value {
     fn from(s: &'b String) -> Self {
+        s.to_owned().into()
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        Value::String(Formatted::new(s))
+    }
+}
+
+impl<'b> From<&'b InternalString> for Value {
+    fn from(s: &'b InternalString) -> Self {
         s.as_str().into()
     }
 }
 
 impl From<InternalString> for Value {
     fn from(s: InternalString) -> Self {
-        Value::from(s.as_str())
+        s.as_str().into()
     }
 }
 


### PR DESCRIPTION
This both helps clarify where and why we use this and allows us to
change the implementation, like using smalll-string optimization.

As part of this, I made it immutable.

For now, I left this more "internal" and it only shows up in APIs for
`Into<InternalString>` with the one exception being `IntoIter` for
tables.  Depending on performance and API friendliness, we can consider
changing `Value`s string type.

BREAKING CHANGE: String type changed in a few places.