### PR TITLE
perf: small-string optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ combine = "4.5.2"
 vec1 = "1"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"], optional = true }
+kstring = { version = "1", features = ["max_inline"] }
 
 [dev-dependencies]
 serde_json = "1.0.44"

--- a/src/internal_string.rs
+++ b/src/internal_string.rs
@@ -3,12 +3,12 @@ use std::str::FromStr;
 
 /// Opaque string storage internal to `toml_edit`
 #[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct InternalString(String);
+pub struct InternalString(kstring::KString);
 
 impl InternalString {
     /// Create an empty string
     pub fn new() -> Self {
-        InternalString(String::new())
+        InternalString(kstring::KString::new())
     }
 
     /// Access the underlying string
@@ -44,21 +44,21 @@ impl AsRef<str> for InternalString {
 impl From<&str> for InternalString {
     #[inline]
     fn from(s: &str) -> Self {
-        String::from(s).into()
+        InternalString(kstring::KString::from_ref(s))
     }
 }
 
 impl From<String> for InternalString {
     #[inline]
     fn from(s: String) -> Self {
-        InternalString(s)
+        InternalString(s.into())
     }
 }
 
 impl From<&String> for InternalString {
     #[inline]
     fn from(s: &String) -> Self {
-        String::from(s).into()
+        InternalString(s.into())
     }
 }
 
@@ -72,7 +72,7 @@ impl From<&InternalString> for InternalString {
 impl From<Box<str>> for InternalString {
     #[inline]
     fn from(s: Box<str>) -> Self {
-        String::from(s).into()
+        InternalString(s.into())
     }
 }
 


### PR DESCRIPTION
For a `key = "value"`, we at least allocate
- `"key"` for the repr
- `"key"` for being able to reuse logic around repr
- `"key"` for the hash table
- ` ` before `=`
- ` ` after `=`
- `"value"` repr
- `"value"` value

Compare this to what `toml-rs` has to deal with
- `"key"`
- `"value"`

This drops the `medium` cargo benchmark from 250us to 203us.  Still not
as big of a drop as I'm hoping for but there are still a lot of spurious
allocations or slow operations we do, like
- Allocations when calling into `Index`
- Allocations in various table functions

I considered making this optional but its such a small dependency, I
figured, eh.

I chose `kstring` over
- `smartstring` because we rarely need mutability and the assumptions it
  makes scares me from using it in anything but a top-level `[[bin]]`
- `compact_str` didn't seem to have benchmarks last I looked
- `smol_str` last benchmarks I ran, it looked to be slower iirc

I used `max_inline` because a saw a couple percentage improvement with `medium`.  I did not benchmark `arc` feature.