### PR TITLE
fix: Remove some recursion to avoid overflow

### DIFF
--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -140,7 +140,7 @@ impl TomlParser {
         }
 
         let table = &mut self.current_table;
-        let table = Self::descend_path(table, &path, 0, true)?;
+        let table = Self::descend_path(table, &path, true)?;
 
         // "Since tables cannot be defined more than once, redefining such tables using a [table] header is not allowed"
         let duplicate_key = table.contains_key(kv.key.get());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -47,7 +47,7 @@ impl TomlParser {
 
         // Look up the table on start to ensure the duplicate_key error points to the right line
         let root = self.document.as_table_mut();
-        let parent_table = Self::descend_path(root, &path[..path.len() - 1], 0, false)?;
+        let parent_table = Self::descend_path(root, &path[..path.len() - 1], false)?;
         let key = &path[path.len() - 1];
         let entry = parent_table
             .entry_format(key)
@@ -72,7 +72,7 @@ impl TomlParser {
         // 1. Look up the table on start to ensure the duplicate_key error points to the right line
         // 2. Ensure any child tables from an implicit table are preserved
         let root = self.document.as_table_mut();
-        let parent_table = Self::descend_path(root, &path[..path.len() - 1], 0, false)?;
+        let parent_table = Self::descend_path(root, &path[..path.len() - 1], false)?;
         let key = &path[path.len() - 1];
         if let Some(entry) = parent_table.remove(key.get()) {
             match entry {
@@ -101,7 +101,7 @@ impl TomlParser {
             assert!(root.is_empty());
             std::mem::swap(&mut table, root);
         } else if self.current_is_array {
-            let parent_table = Self::descend_path(root, &path[..path.len() - 1], 0, false)?;
+            let parent_table = Self::descend_path(root, &path[..path.len() - 1], false)?;
             let key = &path[path.len() - 1];
 
             let entry = parent_table
@@ -112,7 +112,7 @@ impl TomlParser {
                 .ok_or_else(|| duplicate_key(&path, path.len() - 1))?;
             array.push(table);
         } else {
-            let parent_table = Self::descend_path(root, &path[..path.len() - 1], 0, false)?;
+            let parent_table = Self::descend_path(root, &path[..path.len() - 1], false)?;
             let key = &path[path.len() - 1];
 
             let entry = parent_table.entry_format(key);

--- a/src/table.rs
+++ b/src/table.rs
@@ -213,13 +213,13 @@ impl Table {
     }
 
     /// Gets the given key's corresponding entry in the Table for in-place manipulation.
-    pub fn entry_format<'a>(&'a mut self, key: &'a Key) -> Entry<'a> {
+    pub fn entry_format<'a>(&'a mut self, key: &Key) -> Entry<'a> {
         // Accept a `&Key` to be consistent with `entry`
         match self.items.entry(key.get().into()) {
             indexmap::map::Entry::Occupied(entry) => Entry::Occupied(OccupiedEntry { entry }),
             indexmap::map::Entry::Vacant(entry) => Entry::Vacant(VacantEntry {
                 entry,
-                key: Some(key),
+                key: Some(key.to_owned()),
             }),
         }
     }
@@ -568,7 +568,7 @@ impl<'a> OccupiedEntry<'a> {
 /// A view into a single empty location in a `IndexMap`.
 pub struct VacantEntry<'a> {
     entry: indexmap::map::VacantEntry<'a, InternalString, TableKeyValue>,
-    key: Option<&'a Key>,
+    key: Option<Key>,
 }
 
 impl<'a> VacantEntry<'a> {
@@ -590,7 +590,8 @@ impl<'a> VacantEntry<'a> {
     /// Sets the value of the entry with the VacantEntry's key,
     /// and returns a mutable reference to it
     pub fn insert(self, value: Item) -> &'a mut Item {
-        let key = self.key.cloned().unwrap_or_else(|| Key::new(self.key()));
-        &mut self.entry.insert(TableKeyValue::new(key, value)).value
+        let entry = self.entry;
+        let key = self.key.unwrap_or_else(|| Key::new(entry.key().as_str()));
+        &mut entry.insert(TableKeyValue::new(key, value)).value
     }
 }


### PR DESCRIPTION
This is a part of #206.  This wasn't even my goal but to work out what
was going on with lifetimes which led to the loosening of lifetimes on
`*Table::entry_format`.

Hopefully this will also help with performance.