### PR TITLE
refactor: Drop vec1 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ easy = ["serde"]
 [dependencies]
 indexmap = "1.7"
 combine = "4.5.2"
-vec1 = "1"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"], optional = true }
 kstring = { version = "1", features = ["max_inline"] }

--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -56,8 +56,8 @@ parser! {
             char(KEYVAL_SEP),
             (ws(), value(), line_trailing())
         ).map(|(key, _, v)| {
-            let mut path = key.into_vec();
-            let key = path.pop().expect("Was vec1, so at least one exists");
+            let mut path = key;
+            let key = path.pop().expect("grammar ensures at least 1");
 
             let (pre, v, suf) = v;
             let v = v.decorated(pre, suf);

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -90,8 +90,8 @@ parse!(keyval() -> (Vec<Key>, TableKeyValue), {
         char(KEYVAL_SEP),
         (ws(), value(), ws()),
     ).map(|(key, _, v)| {
-        let mut path = key.into_vec();
-        let key = path.pop().expect("Was vec1, so at least one exists");
+        let mut path = key;
+        let key = path.pop().expect("grammar ensures at least 1");
 
         let (pre, v, suf) = v;
         let v = v.decorated(pre, suf);

--- a/src/parser/key.rs
+++ b/src/parser/key.rs
@@ -7,11 +7,10 @@ use combine::parser::char::char;
 use combine::parser::range::{recognize_with_value, take_while1};
 use combine::stream::RangeStream;
 use combine::*;
-use vec1::Vec1;
 
 // key = simple-key / dotted-key
 // dotted-key = simple-key 1*( dot-sep simple-key )
-parse!(key() -> Vec1<Key>, {
+parse!(key() -> Vec<Key>, {
     sep_by1(
         attempt((
             ws(),
@@ -21,7 +20,7 @@ parse!(key() -> Vec1<Key>, {
             Key::new(key).with_repr_unchecked(Repr::new_unchecked(raw)).with_decor(Decor::new(pre, suffix))
         }),
         char(DOT_SEP)
-    ).map(|k| Vec1::try_from_vec(k).expect("parser should guarantee this"))
+    )
 });
 
 // simple-key = quoted-key / unquoted-key

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -25,7 +25,6 @@ use crate::key::Key;
 use crate::parser::errors::CustomError;
 use crate::repr::Decor;
 use crate::{ArrayOfTables, Document, Entry, Item, Table};
-use vec1::Vec1;
 
 pub(crate) struct TomlParser {
     document: Box<Document>,
@@ -39,9 +38,10 @@ pub(crate) struct TomlParser {
 impl TomlParser {
     pub(crate) fn start_aray_table(
         &mut self,
-        path: Vec1<Key>,
+        path: Vec<Key>,
         decor: Decor,
     ) -> Result<(), CustomError> {
+        debug_assert!(!path.is_empty());
         debug_assert!(self.current_table.is_empty());
         debug_assert!(self.current_table_path.is_empty());
 
@@ -60,12 +60,13 @@ impl TomlParser {
         self.current_table.decor = decor;
         self.current_table.set_position(self.current_table_position);
         self.current_is_array = true;
-        self.current_table_path = path.into_vec();
+        self.current_table_path = path;
 
         Ok(())
     }
 
-    pub(crate) fn start_table(&mut self, path: Vec1<Key>, decor: Decor) -> Result<(), CustomError> {
+    pub(crate) fn start_table(&mut self, path: Vec<Key>, decor: Decor) -> Result<(), CustomError> {
+        debug_assert!(!path.is_empty());
         debug_assert!(self.current_table.is_empty());
         debug_assert!(self.current_table_path.is_empty());
 
@@ -87,7 +88,7 @@ impl TomlParser {
         self.current_table.decor = decor;
         self.current_table.set_position(self.current_table_position);
         self.current_is_array = false;
-        self.current_table_path = path.into_vec();
+        self.current_table_path = path;
 
         Ok(())
     }

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -15,7 +15,6 @@ use std::mem;
 // https://github.com/rust-lang/rust/issues/41358
 #[allow(unused_imports)]
 use std::ops::DerefMut;
-use vec1::Vec1;
 
 // std-table-open  = %x5B ws     ; [ Left square bracket
 const STD_TABLE_OPEN: char = '[';
@@ -116,7 +115,7 @@ impl TomlParser {
         Ok(table)
     }
 
-    fn on_std_header(&mut self, path: Vec1<Key>, trailing: &str) -> Result<(), CustomError> {
+    fn on_std_header(&mut self, path: Vec<Key>, trailing: &str) -> Result<(), CustomError> {
         debug_assert!(!path.is_empty());
 
         self.finalize_table()?;
@@ -126,7 +125,7 @@ impl TomlParser {
         Ok(())
     }
 
-    fn on_array_header(&mut self, path: Vec1<Key>, trailing: &str) -> Result<(), CustomError> {
+    fn on_array_header(&mut self, path: Vec<Key>, trailing: &str) -> Result<(), CustomError> {
         debug_assert!(!path.is_empty());
 
         self.finalize_table()?;


### PR DESCRIPTION
Looks like we didn't actually get much out of this and looking at
optimizations that this gets in the way of.