### PR TITLE
perf: Remove vec alloc on every key-value pair

### DIFF
--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -2,7 +2,7 @@ use crate::document::Document;
 use crate::key::Key;
 use crate::parser::errors::CustomError;
 use crate::parser::inline_table::KEYVAL_SEP;
-use crate::parser::key::key;
+use crate::parser::key::key_path;
 use crate::parser::table::table;
 use crate::parser::trivia::{comment, line_ending, line_trailing, newline, ws};
 use crate::parser::value::value;
@@ -52,13 +52,10 @@ parser! {
          From<crate::parser::errors::CustomError>
     ] {
         (
-            key(),
+            key_path(),
             char(KEYVAL_SEP),
             (ws(), value(), line_trailing())
-        ).map(|(key, _, v)| {
-            let mut path = key;
-            let key = path.pop().expect("grammar ensures at least 1");
-
+        ).map(|((path, key), _, v)| {
             let (pre, v, suf) = v;
             let v = v.decorated(pre, suf);
             (

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -1,6 +1,6 @@
 use crate::key::Key;
 use crate::parser::errors::CustomError;
-use crate::parser::key::key;
+use crate::parser::key::key_path;
 use crate::parser::table::duplicate_key;
 use crate::parser::trivia::ws;
 use crate::parser::value::value;
@@ -86,13 +86,10 @@ parse!(inline_table_keyvals() -> (Vec<(Vec<Key>, TableKeyValue)>, &'a str), {
 
 parse!(keyval() -> (Vec<Key>, TableKeyValue), {
     (
-        key(),
+        key_path(),
         char(KEYVAL_SEP),
         (ws(), value(), ws()),
-    ).map(|(key, _, v)| {
-        let mut path = key;
-        let key = path.pop().expect("grammar ensures at least 1");
-
+    ).map(|((path, key), _, v)| {
         let (pre, v, suf) = v;
         let v = v.decorated(pre, suf);
         (


### PR DESCRIPTION
We represent all paths as `Vec1<Key>`, requiring allocating at least one
element for every key-value pair.  This change gets us a stack-value for
the one element, so in the majority of cases, we bypass the heap.