### PR TITLE
Make it easier to profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,5 +65,8 @@ harness = false
 name = "linear"
 harness = false
 
+[profile.release]
+debug = 1
+
 [profile.dev]
 opt-level = 1


### PR DESCRIPTION
Its easy to forget to set this when profiling, making the results not as
friendly.  It looks like this only has impact for final artifacts
created in the `Cargo.toml` its set in, so this shouldn't impact people
use `toml_edit` as a lib, just our benchmarks and profiling.