### PR TITLE
perf: Switch to byte processing

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -130,14 +130,20 @@ impl FromStr for Datetime {
 
     /// Parses a value from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use combine::stream::position::{IndexPositioner, Positioner};
         use combine::EasyParser;
-        let result = parser::datetime::date_time().easy_parse(Stream::new(s));
+
+        let b = s.as_bytes();
+        let result = parser::datetime::date_time().easy_parse(Stream::new(b));
         match result {
-            Ok((_, ref rest)) if !rest.input.is_empty() => {
-                Err(parser::TomlError::from_unparsed(rest.positioner, s))
-            }
+            Ok((_, ref rest)) if !rest.input.is_empty() => Err(parser::TomlError::from_unparsed(
+                (&rest.positioner
+                    as &dyn Positioner<usize, Position = usize, Checkpoint = IndexPositioner>)
+                    .position(),
+                b,
+            )),
             Ok((dt, _)) => Ok(dt),
-            Err(e) => Err(parser::TomlError::new(e, s)),
+            Err(e) => Err(parser::TomlError::new(e, b)),
         }
     }
 }
@@ -205,14 +211,20 @@ impl FromStr for Date {
 
     /// Parses a value from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use combine::stream::position::{IndexPositioner, Positioner};
         use combine::EasyParser;
-        let result = parser::datetime::full_date().easy_parse(Stream::new(s));
+
+        let b = s.as_bytes();
+        let result = parser::datetime::full_date().easy_parse(Stream::new(b));
         match result {
-            Ok((_, ref rest)) if !rest.input.is_empty() => {
-                Err(parser::TomlError::from_unparsed(rest.positioner, s))
-            }
+            Ok((_, ref rest)) if !rest.input.is_empty() => Err(parser::TomlError::from_unparsed(
+                (&rest.positioner
+                    as &dyn Positioner<usize, Position = usize, Checkpoint = IndexPositioner>)
+                    .position(),
+                b,
+            )),
             Ok((dt, _)) => Ok(dt),
-            Err(e) => Err(parser::TomlError::new(e, s)),
+            Err(e) => Err(parser::TomlError::new(e, b)),
         }
     }
 }
@@ -276,14 +288,20 @@ impl FromStr for Time {
 
     /// Parses a value from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use combine::stream::position::{IndexPositioner, Positioner};
         use combine::EasyParser;
-        let result = parser::datetime::partial_time().easy_parse(Stream::new(s));
+
+        let b = s.as_bytes();
+        let result = parser::datetime::partial_time().easy_parse(Stream::new(b));
         match result {
-            Ok((_, ref rest)) if !rest.input.is_empty() => {
-                Err(parser::TomlError::from_unparsed(rest.positioner, s))
-            }
+            Ok((_, ref rest)) if !rest.input.is_empty() => Err(parser::TomlError::from_unparsed(
+                (&rest.positioner
+                    as &dyn Positioner<usize, Position = usize, Checkpoint = IndexPositioner>)
+                    .position(),
+                b,
+            )),
             Ok((dt, _)) => Ok(dt),
-            Err(e) => Err(parser::TomlError::new(e, s)),
+            Err(e) => Err(parser::TomlError::new(e, b)),
         }
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -64,6 +64,6 @@ impl FromStr for Document {
 
     /// Parses a document from a &str
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parser::TomlParser::parse(s)
+        parser::TomlParser::parse(s.as_bytes())
     }
 }

--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -1,7 +1,7 @@
 use crate::parser::trivia::ws_comment_newline;
 use crate::parser::value::value;
 use crate::{Array, Value};
-use combine::parser::char::char;
+use combine::parser::byte::byte;
 use combine::parser::range::recognize_with_value;
 use combine::stream::RangeStream;
 use combine::*;
@@ -10,18 +10,18 @@ use combine::*;
 
 // array = array-open array-values array-close
 parse!(array() -> Array, {
-    between(char(ARRAY_OPEN), char(ARRAY_CLOSE),
+    between(byte(ARRAY_OPEN), byte(ARRAY_CLOSE),
             array_values())
 });
 
 // note: we're omitting ws and newlines here, because
 // they should be part of the formatted values
 // array-open  = %x5B ws-newline  ; [
-const ARRAY_OPEN: char = '[';
+const ARRAY_OPEN: u8 = b'[';
 // array-close = ws-newline %x5D  ; ]
-const ARRAY_CLOSE: char = ']';
+const ARRAY_CLOSE: u8 = b']';
 // array-sep = ws %x2C ws  ; , Comma
-const ARRAY_SEP: char = ',';
+const ARRAY_SEP: u8 = b',';
 
 // note: this rule is modified
 // array-values = [ ( array-value array-sep array-values ) /
@@ -30,15 +30,15 @@ parse!(array_values() -> Array, {
     (
         optional(
             recognize_with_value(
-                sep_end_by1(array_value(), char(ARRAY_SEP))
-            ).map(|(r, v): (&'a str, Array)| (v, r.ends_with(',')))
+                sep_end_by1(array_value(), byte(ARRAY_SEP))
+            ).map(|(r, v): (&'a [u8], Array)| (v, r[r.len() - 1] == b','))
         ),
         ws_comment_newline(),
-    ).map(|(array, trailing)| {
+    ).and_then::<_, _, std::str::Utf8Error>(|(array, trailing)| {
         let (mut array, comma) = array.unwrap_or_default();
         array.set_trailing_comma(comma);
-        array.set_trailing(trailing);
-        array
+        array.set_trailing(std::str::from_utf8(trailing)?);
+        Ok(array)
     })
 });
 
@@ -47,5 +47,11 @@ parse!(array_value() -> Value, {
         ws_comment_newline(),
         value(),
         ws_comment_newline(),
-    )).map(|(ws1, v, ws2)| v.decorated(ws1, ws2))
+    )).and_then::<_, _, std::str::Utf8Error>(|(ws1, v, ws2)| {
+        let v = v.decorated(
+            std::str::from_utf8(ws1)?,
+            std::str::from_utf8(ws2)?,
+        );
+        Ok(v)
+    })
 });

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -11,13 +11,13 @@ pub struct TomlError {
 }
 
 impl TomlError {
-    pub(crate) fn new(error: ParseError<char, &str, SourcePosition>, input: &str) -> Self {
+    pub(crate) fn new(error: ParseError<u8, &[u8], usize>, input: &[u8]) -> Self {
         Self {
             message: format!("{}", FancyError::new(error, input)),
         }
     }
 
-    pub(crate) fn from_unparsed(pos: SourcePosition, input: &str) -> Self {
+    pub(crate) fn from_unparsed(pos: usize, input: &[u8]) -> Self {
         Self::new(
             ParseError::new(pos, CustomError::UnparsedLine.into()),
             input,
@@ -55,26 +55,41 @@ impl StdError for TomlError {
 
 #[derive(Debug)]
 pub(crate) struct FancyError<'a> {
-    error: ParseError<char, &'a str, SourcePosition>,
-    input: &'a str,
+    errors: Vec<Error<char, String>>,
+    position: SourcePosition,
+    input: &'a [u8],
 }
 
 impl<'a> FancyError<'a> {
-    pub(crate) fn new(error: ParseError<char, &'a str, SourcePosition>, input: &'a str) -> Self {
-        Self { error, input }
+    pub(crate) fn new(error: ParseError<u8, &'a [u8], usize>, input: &'a [u8]) -> Self {
+        let position = translate_position(input, error.position);
+        let errors: Vec<_> = error
+            .errors
+            .into_iter()
+            .map(|e| {
+                e.map_token(char::from)
+                    .map_range(|s| String::from_utf8_lossy(s).into_owned())
+            })
+            .collect();
+        Self {
+            errors,
+            position,
+            input,
+        }
     }
 }
 
 impl<'a> Display for FancyError<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let SourcePosition { line, column } = self.error.position;
+        let SourcePosition { line, column } = self.position;
 
         let offset = line.to_string().len();
         let content = self
             .input
-            .split('\n')
+            .split(|b| *b == b'\n')
             .nth((line - 1) as usize)
             .expect("line");
+        let content = String::from_utf8_lossy(content);
 
         writeln!(f, "TOML parse error at line {}, column {}", line, column)?;
 
@@ -98,7 +113,121 @@ impl<'a> Display for FancyError<'a> {
         }
         writeln!(f, "^")?;
 
-        Error::fmt_errors(self.error.errors.as_ref(), f)
+        Error::fmt_errors(self.errors.as_ref(), f)
+    }
+}
+
+fn translate_position(input: &[u8], index: usize) -> SourcePosition {
+    if input.is_empty() {
+        return SourcePosition {
+            line: 1,
+            column: (index + 1) as i32,
+        };
+    }
+
+    let safe_index = index.min(input.len() - 1);
+    let column_offset = index - safe_index;
+    let index = safe_index;
+
+    let nl = input[0..index]
+        .iter()
+        .rev()
+        .enumerate()
+        .find(|(_, b)| **b == b'\n')
+        .map(|(nl, _)| index - nl - 1);
+    let line_start = match nl {
+        Some(nl) => nl + 1,
+        None => 0,
+    };
+    let line = input[0..line_start].iter().filter(|b| **b == b'\n').count() + 1;
+    let line = line as i32;
+
+    let column = std::str::from_utf8(&input[line_start..=index])
+        .map(|s| s.chars().count())
+        .unwrap_or_else(|_| index - line_start + 1);
+    let column = (column + column_offset) as i32;
+
+    SourcePosition { line, column }
+}
+
+#[cfg(test)]
+mod test_translate_position {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let input = b"";
+        let index = 0;
+        let position = translate_position(&input[..], index);
+        assert_eq!(position, SourcePosition { line: 1, column: 1 });
+    }
+
+    #[test]
+    fn start() {
+        let input = b"Hello";
+        let index = 0;
+        let position = translate_position(&input[..], index);
+        assert_eq!(position, SourcePosition { line: 1, column: 1 });
+    }
+
+    #[test]
+    fn end() {
+        let input = b"Hello";
+        let index = input.len() - 1;
+        let position = translate_position(&input[..], index);
+        assert_eq!(
+            position,
+            SourcePosition {
+                line: 1,
+                column: input.len() as i32
+            }
+        );
+    }
+
+    #[test]
+    fn after() {
+        let input = b"Hello";
+        let index = input.len();
+        let position = translate_position(&input[..], index);
+        assert_eq!(
+            position,
+            SourcePosition {
+                line: 1,
+                column: (input.len() + 1) as i32
+            }
+        );
+    }
+
+    #[test]
+    fn first_line() {
+        let input = b"Hello\nWorld\n";
+        let index = 2;
+        let position = translate_position(&input[..], index);
+        assert_eq!(position, SourcePosition { line: 1, column: 3 });
+    }
+
+    #[test]
+    fn end_of_line() {
+        let input = b"Hello\nWorld\n";
+        let index = 5;
+        let position = translate_position(&input[..], index);
+        assert_eq!(position, SourcePosition { line: 1, column: 6 });
+    }
+
+    #[test]
+    fn start_of_second_line() {
+        let input = b"Hello\nWorld\n";
+        let index = 6;
+        let position = translate_position(&input[..], index);
+        assert_eq!(position, SourcePosition { line: 2, column: 1 });
+    }
+
+    #[test]
+    fn second_line() {
+        let input = b"Hello\nWorld\n";
+        let index = 8;
+        let position = translate_position(&input[..], index);
+        assert_eq!(position, SourcePosition { line: 2, column: 3 });
     }
 }
 

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -6,7 +6,7 @@ use crate::parser::trivia::ws;
 use crate::parser::value::value;
 use crate::table::TableKeyValue;
 use crate::{InlineTable, InternalString, Item, Value};
-use combine::parser::char::char;
+use combine::parser::byte::byte;
 use combine::stream::RangeStream;
 use combine::*;
 
@@ -14,7 +14,7 @@ use combine::*;
 
 // inline-table = inline-table-open inline-table-keyvals inline-table-close
 parse!(inline_table() -> InlineTable, {
-    between(char(INLINE_TABLE_OPEN), char(INLINE_TABLE_CLOSE),
+    between(byte(INLINE_TABLE_OPEN), byte(INLINE_TABLE_CLOSE),
             inline_table_keyvals().and_then(|(kv, p)| table_from_pairs(kv, p)))
 });
 
@@ -66,13 +66,13 @@ fn descend_path<'a>(
 }
 
 // inline-table-open  = %x7B ws     ; {
-const INLINE_TABLE_OPEN: char = '{';
+const INLINE_TABLE_OPEN: u8 = b'{';
 // inline-table-close = ws %x7D     ; }
-const INLINE_TABLE_CLOSE: char = '}';
+const INLINE_TABLE_CLOSE: u8 = b'}';
 // inline-table-sep   = ws %x2C ws  ; , Comma
-const INLINE_TABLE_SEP: char = ',';
+const INLINE_TABLE_SEP: u8 = b',';
 // keyval-sep = ws %x3D ws ; =
-pub(crate) const KEYVAL_SEP: char = '=';
+pub(crate) const KEYVAL_SEP: u8 = b'=';
 
 // inline-table-keyvals = [ inline-table-keyvals-non-empty ]
 // inline-table-keyvals-non-empty =
@@ -81,7 +81,7 @@ pub(crate) const KEYVAL_SEP: char = '=';
 
 parse!(inline_table_keyvals() -> (Vec<(Vec<Key>, TableKeyValue)>, &'a str), {
     (
-        sep_by(keyval(), char(INLINE_TABLE_SEP)),
+        sep_by(keyval(), byte(INLINE_TABLE_SEP)),
         ws(),
     )
 });
@@ -89,7 +89,7 @@ parse!(inline_table_keyvals() -> (Vec<(Vec<Key>, TableKeyValue)>, &'a str), {
 parse!(keyval() -> (Vec<Key>, TableKeyValue), {
     (
         key(),
-        char(KEYVAL_SEP),
+        byte(KEYVAL_SEP),
         (ws(), value(), ws()),
     ).map(|(key, _, v)| {
         let mut path = key;

--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -6,12 +6,13 @@ macro_rules! parse (
             pub(crate) fn $name['a, I]($($arg : $arg_type),*)(I) -> $ret
                 where
                 [I: RangeStream<
-                 Range = &'a str,
-                 Token = char>,
-                 I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
-                 <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
+                 Range = &'a [u8],
+                 Token = u8>,
+                 I::Error: ParseError<u8, &'a [u8], <I as StreamOnce>::Position>,
+                 <I::Error as ParseError<u8, &'a [u8], <I as StreamOnce>::Position>>::StreamError:
                  From<std::num::ParseIntError> +
                  From<std::num::ParseFloatError> +
+                 From<std::str::Utf8Error> +
                  From<crate::parser::errors::CustomError>
                 ]
             {
@@ -29,12 +30,13 @@ macro_rules! toml_parser (
             fn $name['a, 'b, I]($argh: &'b RefCell<TomlParser>)(I) -> ()
             where
                 [I: RangeStream<
-                 Range = &'a str,
-                 Token = char>,
-                 I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
-                 <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
+                 Range = &'a [u8],
+                 Token = u8>,
+                 I::Error: ParseError<u8, &'a [u8], <I as StreamOnce>::Position>,
+                 <I::Error as ParseError<u8, &'a [u8], <I as StreamOnce>::Position>>::StreamError:
                  From<std::num::ParseIntError> +
                  From<std::num::ParseFloatError> +
+                 From<std::str::Utf8Error> +
                  From<crate::parser::errors::CustomError>
                 ]
             {

--- a/src/parser/trivia.rs
+++ b/src/parser/trivia.rs
@@ -1,39 +1,56 @@
-use combine::parser::char::{char, crlf, newline as lf};
+use combine::parser::byte::{byte, crlf, newline as lf};
 use combine::parser::range::{recognize, take_while, take_while1};
 use combine::stream::RangeStream;
 use combine::*;
 
+pub(crate) unsafe fn from_utf8_unchecked<'b>(
+    bytes: &'b [u8],
+    safety_justification: &'static str,
+) -> &'b str {
+    if cfg!(debug_assertions) {
+        // Catch problems more quickly when testing
+        std::str::from_utf8(bytes).expect(safety_justification)
+    } else {
+        std::str::from_utf8_unchecked(bytes)
+    }
+}
+
 // wschar = ( %x20 /              ; Space
 //            %x09 )              ; Horizontal tab
 #[inline]
-pub(crate) fn is_wschar(c: char) -> bool {
-    matches!(c, ' ' | '\t')
+pub(crate) fn is_wschar(c: u8) -> bool {
+    matches!(c, b' ' | b'\t')
 }
 
 // ws = *wschar
 parse!(ws() -> &'a str, {
-    take_while(is_wschar)
+    take_while(is_wschar).map(|b| {
+        unsafe { from_utf8_unchecked(b, "`is_wschar` filters out on-ASCII") }
+    })
 });
 
 // non-ascii = %x80-D7FF / %xE000-10FFFF
 #[inline]
-pub(crate) fn is_non_ascii(c: char) -> bool {
-    matches!(c, '\u{80}'..='\u{D7FF}' | '\u{E000}'..='\u{10FFFF}')
+pub(crate) fn is_non_ascii(c: u8) -> bool {
+    // - ASCII is 0xxxxxxx
+    // - First byte for UTF-8 is 11xxxxxx
+    // - Subsequent UTF-8 bytes are 10xxxxxx
+    matches!(c, 0x80..=0xff)
 }
 
 // non-eol = %x09 / %x20-7E / non-ascii
 #[inline]
-fn is_non_eol(c: char) -> bool {
-    matches!(c, '\u{09}' | '\u{20}'..='\u{7E}') | is_non_ascii(c)
+fn is_non_eol(c: u8) -> bool {
+    matches!(c, 0x09 | 0x20..=0x7E) | is_non_ascii(c)
 }
 
 // comment-start-symbol = %x23 ; #
-const COMMENT_START_SYMBOL: char = '#';
+const COMMENT_START_SYMBOL: u8 = b'#';
 
 // comment = comment-start-symbol *non-eol
-parse!(comment() -> &'a str, {
+parse!(comment() -> &'a [u8], {
     recognize((
-        attempt(char(COMMENT_START_SYMBOL)),
+        attempt(byte(COMMENT_START_SYMBOL)),
         take_while(is_non_eol),
     ))
 });
@@ -50,10 +67,12 @@ parse!(newline() -> char, {
 parse!(ws_newline() -> &'a str, {
     recognize(
         skip_many(choice((
-            newline().map(|_| "\n"),
+            newline().map(|_| &b"\n"[..]),
             take_while1(is_wschar),
         ))),
-    )
+    ).map(|b| {
+        unsafe { from_utf8_unchecked(b, "`is_wschar` and `newline` filters out on-ASCII") }
+    })
 });
 
 // ws-newlines      = newline *( wschar / newline )
@@ -61,19 +80,21 @@ parse!(ws_newlines() -> &'a str, {
     recognize((
         newline(),
         ws_newline(),
-    ))
+    )).map(|b| {
+        unsafe { from_utf8_unchecked(b, "`is_wschar` and `newline` filters out on-ASCII") }
+    })
 });
 
 // note: this rule is not present in the original grammar
 // ws-comment-newline = *( ws-newline-nonempty / comment )
-parse!(ws_comment_newline() -> &'a str, {
+parse!(ws_comment_newline() -> &'a [u8], {
     recognize(
         skip_many(
             choice((
                 skip_many1(
                     choice((
                         take_while1(is_wschar),
-                        newline().map(|_| "\n"),
+                        newline().map(|_| &b"\n"[..]),
                     ))
                 ),
                 comment().map(|_| ()),
@@ -93,7 +114,7 @@ parse!(line_ending() -> &'a str, {
 
 // note: this rule is not present in the original grammar
 // line-trailing = ws [comment] skip-line-ending
-parse!(line_trailing() -> &'a str, {
+parse!(line_trailing() -> &'a [u8], {
     recognize((
         ws(),
         optional(comment()),

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -3,6 +3,7 @@ use crate::parser::datetime::date_time;
 use crate::parser::inline_table::inline_table;
 use crate::parser::numbers::{boolean, float, integer};
 use crate::parser::strings::string;
+use crate::parser::trivia::from_utf8_unchecked;
 use crate::repr::{Formatted, Repr};
 use crate::value as v;
 use crate::Value;
@@ -31,28 +32,33 @@ parse!(value() -> v::Value, {
             .map(v::Value::from),
         integer()
             .map(v::Value::from),
-    ))).map(|(raw, value)| apply_raw(value, raw))
+    ))).and_then(|(raw, value)| apply_raw(value, raw))
 });
 
-fn apply_raw(mut val: Value, raw: &str) -> Value {
+fn apply_raw(mut val: Value, raw: &[u8]) -> Result<Value, std::str::Utf8Error> {
     match val {
         Value::String(ref mut f) => {
+            let raw = std::str::from_utf8(raw)?;
             f.set_repr_unchecked(Repr::new_unchecked(raw));
         }
         Value::Integer(ref mut f) => {
+            let raw = unsafe { from_utf8_unchecked(raw, "`integer()` filters out non-ASCII") };
             f.set_repr_unchecked(Repr::new_unchecked(raw));
         }
         Value::Float(ref mut f) => {
+            let raw = unsafe { from_utf8_unchecked(raw, "`float()` filters out non-ASCII") };
             f.set_repr_unchecked(Repr::new_unchecked(raw));
         }
         Value::Boolean(ref mut f) => {
+            let raw = unsafe { from_utf8_unchecked(raw, "`boolean()` filters out non-ASCII") };
             f.set_repr_unchecked(Repr::new_unchecked(raw));
         }
         Value::Datetime(ref mut f) => {
+            let raw = unsafe { from_utf8_unchecked(raw, "`date_time()` filters out non-ASCII") };
             f.set_repr_unchecked(Repr::new_unchecked(raw));
         }
         Value::Array(_) | Value::InlineTable(_) => {}
     };
     val.decorate("", "");
-    val
+    Ok(val)
 }


### PR DESCRIPTION
The grammar is fairly neutral, so long as we can handle "non-ASCII".

This does introduce `unsafe` for cases where the grammar guarantees
we'll have valid UTF-8, to avoid validation.  There might be some more
cases where we can bypass the checks; I was being cautious and only
using `unsafe` for 7-bit ASCII.  If we ensure our input is only UTF-8
and we only split on 7-bit ASCII, we are probably safe to use bypass
validation everywhere.

So this saves us having to encode UTF0-8 as `char` at the cost of some
UTF-8 validation.  Looks like this gives us a 6-12% reduction in parsing
time.