### PR TITLE
fix(grammar): Support trailing quotes

### DIFF
--- a/tests/decoder_compliance.rs
+++ b/tests/decoder_compliance.rs
@@ -2,9 +2,6 @@ mod decoder;
 
 fn main() {
     let decoder = decoder::Decoder;
-    let mut harness = toml_test_harness::DecoderHarness::new(decoder);
-    harness
-        .ignore(["valid/string/multiline-quotes.toml"])
-        .unwrap();
+    let harness = toml_test_harness::DecoderHarness::new(decoder);
     harness.test();
 }

--- a/tests/easy_decoder_compliance.rs
+++ b/tests/easy_decoder_compliance.rs
@@ -4,10 +4,7 @@ mod easy_decoder;
 #[cfg(feature = "easy")]
 fn main() {
     let decoder = easy_decoder::Decoder;
-    let mut harness = toml_test_harness::DecoderHarness::new(decoder);
-    harness
-        .ignore(["valid/string/multiline-quotes.toml"])
-        .unwrap();
+    let harness = toml_test_harness::DecoderHarness::new(decoder);
     harness.test();
 }
 

--- a/tests/easy_encoder_compliance.rs
+++ b/tests/easy_encoder_compliance.rs
@@ -7,13 +7,7 @@ mod easy_encoder;
 fn main() {
     let encoder = easy_encoder::Encoder;
     let decoder = easy_decoder::Decoder;
-    let mut harness = toml_test_harness::EncoderHarness::new(encoder, decoder);
-    harness
-        .ignore([
-            // Can't verify until decoder is fixed
-            "valid/string/multiline-quotes.toml",
-        ])
-        .unwrap();
+    let harness = toml_test_harness::EncoderHarness::new(encoder, decoder);
     harness.test();
 }
 

--- a/tests/encoder_compliance.rs
+++ b/tests/encoder_compliance.rs
@@ -4,12 +4,6 @@ mod encoder;
 fn main() {
     let encoder = encoder::Encoder;
     let decoder = decoder::Decoder;
-    let mut harness = toml_test_harness::EncoderHarness::new(encoder, decoder);
-    harness
-        .ignore([
-            // Can't verify until decoder is fixed
-            "valid/string/multiline-quotes.toml",
-        ])
-        .unwrap();
+    let harness = toml_test_harness::EncoderHarness::new(encoder, decoder);
     harness.test();
 }


### PR DESCRIPTION
Required munging the grammar so `combine` could understand, but we got
it!

Fixes #128