### PR TITLE
perf(parser): Specially dispatch hotloops

### DIFF
--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -17,7 +17,7 @@ parse!(array() -> Array, {
 // note: we're omitting ws and newlines here, because
 // they should be part of the formatted values
 // array-open  = %x5B ws-newline  ; [
-const ARRAY_OPEN: u8 = b'[';
+pub(crate) const ARRAY_OPEN: u8 = b'[';
 // array-close = ws-newline %x5D  ; ]
 const ARRAY_CLOSE: u8 = b']';
 // array-sep = ws %x2C ws  ; , Comma

--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -93,12 +93,15 @@ impl TomlParser {
             .with(choice((
                 eof(),
                 skip_many1(
-                    choice((
-                        parse_comment(&parser),
-                        keyval(&parser),
-                        table(&parser),
-                        parse_newline(&parser),
-                    ))
+                    look_ahead(any()).then(|e| {
+                        dispatch!(e;
+                            crate::parser::trivia::COMMENT_START_SYMBOL => parse_comment(&parser),
+                            crate::parser::table::STD_TABLE_OPEN => table(&parser),
+                            crate::parser::trivia::LF |
+                            crate::parser::trivia::CR => parse_newline(&parser),
+                            _ => keyval(&parser),
+                        )
+                    })
                     .skip(parse_ws(&parser)),
                 ),
             )))

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -66,7 +66,7 @@ fn descend_path<'a>(
 }
 
 // inline-table-open  = %x7B ws     ; {
-const INLINE_TABLE_OPEN: u8 = b'{';
+pub(crate) const INLINE_TABLE_OPEN: u8 = b'{';
 // inline-table-close = ws %x7D     ; }
 const INLINE_TABLE_CLOSE: u8 = b'}';
 // inline-table-sep   = ws %x2C ws  ; , Comma

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -34,7 +34,7 @@ parse!(basic_string() -> String, {
 });
 
 // quotation-mark = %x22            ; "
-const QUOTATION_MARK: u8 = b'"';
+pub(crate) const QUOTATION_MARK: u8 = b'"';
 
 // basic-char = basic-unescaped / escaped
 parse!(basic_chars() -> Cow<'a, str>, {
@@ -218,7 +218,7 @@ parse!(literal_string() -> &'a str, {
 });
 
 // apostrophe = %x27 ; ' apostrophe
-const APOSTROPHE: u8 = b'\'';
+pub(crate) const APOSTROPHE: u8 = b'\'';
 
 // literal-char = %x09 / %x20-26 / %x28-7E / non-ascii
 #[inline]

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -17,7 +17,7 @@ use std::mem;
 use std::ops::DerefMut;
 
 // std-table-open  = %x5B ws     ; [ Left square bracket
-const STD_TABLE_OPEN: u8 = b'[';
+pub(crate) const STD_TABLE_OPEN: u8 = b'[';
 // std-table-close = ws %x5D     ; ] Right square bracket
 const STD_TABLE_CLOSE: u8 = b']';
 // array-table-open  = %x5B.5B ws  ; [[ Double left square bracket

--- a/src/parser/trivia.rs
+++ b/src/parser/trivia.rs
@@ -45,7 +45,7 @@ fn is_non_eol(c: u8) -> bool {
 }
 
 // comment-start-symbol = %x23 ; #
-const COMMENT_START_SYMBOL: u8 = b'#';
+pub(crate) const COMMENT_START_SYMBOL: u8 = b'#';
 
 // comment = comment-start-symbol *non-eol
 parse!(comment() -> &'a [u8], {
@@ -57,6 +57,8 @@ parse!(comment() -> &'a [u8], {
 
 // newline = ( %x0A /              ; LF
 //             %x0D.0A )           ; CRLF
+pub(crate) const LF: u8 = b'\n';
+pub(crate) const CR: u8 = b'\r';
 parse!(newline() -> char, {
     choice((lf(), crlf()))
         .map(|_| '\n')


### PR DESCRIPTION
This took `minimal` from 7.2us to 4.1us when `toml-rs` is 4.9us.

For `medium`, we went from 182us to 160us when `toml-rs` is 127us.

This dropped `Errors::merge` from 7.8% to 4.7% of a sample program's
execution time.