### PR TITLE
fix(serde)!: Disallow direct creation of `Serializer`

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -170,6 +170,7 @@ where
 /// Currently a serializer always writes its output to an in-memory `String`,
 /// which is passed in when creating the serializer itself.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct Serializer {}
 
 impl Serializer {


### PR DESCRIPTION
This is a side effect of not having any members at the moment, so using
`non_exhaustive to work aroung this.

BREAKING CHANGE: To create a `Serializer`, you will need to use
`Serializer::new`.