### PR TITLE
fix(serde): Work with non-transparent newtypes

### DIFF
--- a/src/de/inline_table.rs
+++ b/src/de/inline_table.rs
@@ -21,6 +21,17 @@ impl<'de, 'a> serde::Deserializer<'de> for crate::InlineTable {
         visitor.visit_some(self)
     }
 
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     fn deserialize_struct<V>(
         self,
         _name: &'static str,
@@ -58,7 +69,7 @@ impl<'de, 'a> serde::Deserializer<'de> for crate::InlineTable {
 
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
-        bytes byte_buf map unit newtype_struct
+        bytes byte_buf map unit
         ignored_any unit_struct tuple_struct tuple identifier
     }
 }

--- a/src/de/item.rs
+++ b/src/de/item.rs
@@ -38,6 +38,17 @@ impl<'de, 'a> serde::Deserializer<'de> for ItemDeserializer {
         self.input.deserialize_option(visitor)
     }
 
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     fn deserialize_struct<V>(
         self,
         name: &'static str,
@@ -75,7 +86,7 @@ impl<'de, 'a> serde::Deserializer<'de> for ItemDeserializer {
 
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
-        bytes byte_buf map unit newtype_struct
+        bytes byte_buf map unit
         ignored_any unit_struct tuple_struct tuple identifier
     }
 }
@@ -104,6 +115,17 @@ impl<'de, 'a> serde::Deserializer<'de> for crate::Item {
         V: serde::de::Visitor<'de>,
     {
         visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
     }
 
     // Called when the type to deserialize is an enum, as opposed to a field in the type.
@@ -137,7 +159,7 @@ impl<'de, 'a> serde::Deserializer<'de> for crate::Item {
 
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
-        bytes byte_buf map unit newtype_struct struct
+        bytes byte_buf map unit struct
         ignored_any unit_struct tuple_struct tuple identifier
     }
 }

--- a/src/de/table.rs
+++ b/src/de/table.rs
@@ -21,6 +21,17 @@ impl<'de, 'a> serde::Deserializer<'de> for crate::Table {
         visitor.visit_some(self)
     }
 
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     fn deserialize_struct<V>(
         self,
         _name: &'static str,
@@ -58,7 +69,7 @@ impl<'de, 'a> serde::Deserializer<'de> for crate::Table {
 
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
-        bytes byte_buf map unit newtype_struct
+        bytes byte_buf map unit
         ignored_any unit_struct tuple_struct tuple identifier
     }
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -357,7 +357,6 @@ fn newtypes() {
     }
 
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
-    #[serde(transparent)]
     struct B(u32);
 
     equivalent! {
@@ -374,7 +373,6 @@ fn newtypes2() {
     }
 
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
-    #[serde(transparent)]
     struct B(Option<C>);
 
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]


### PR DESCRIPTION
I had assumed there was a hack in their `Value`s Deserialize and didn't
bother digging in more until `cargo` test cases forced me to. Turns out,
it was in the Deserializer and I missed a simple case.