### PR TITLE
fix: Don't panic on easy::Value::to_string

### DIFF
--- a/src/easy/value.rs
+++ b/src/easy/value.rs
@@ -230,9 +230,19 @@ impl Value {
 
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        super::to_string_pretty(self)
-            .map_err(|_| std::fmt::Error)?
-            .fmt(f)
+        match *self {
+            Value::String(..)
+            | Value::Integer(..)
+            | Value::Float(..)
+            | Value::Boolean(..)
+            | Value::Datetime(..)
+            | Value::Array(..) => crate::ser::to_item(self)
+                .map_err(|_| std::fmt::Error)?
+                .fmt(f),
+            Value::Table(_) => crate::ser::to_string_pretty(self)
+                .map_err(|_| std::fmt::Error)?
+                .fmt(f),
+        }
     }
 }
 


### PR DESCRIPTION
Since this is untyped, I figure we can do this to make cargo happy.
Still trying to avoid generalizing this.  We'll see if that sticks.