### PR TITLE
add visit and visit_mut APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+          args: --all-features --all-targets
   
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ harness = false
 name = "linear"
 harness = false
 
+[[example]]
+name = "visit"
+test = true
+
 [profile.release]
 debug = 1
 

--- a/examples/visit.rs
+++ b/examples/visit.rs
@@ -1,0 +1,218 @@
+//! Example for how to use `VisitMut` to iterate over a table.
+
+use toml_edit::visit_mut::*;
+use toml_edit::{Array, Document, InlineTable, Item, KeyMut, Table, Value};
+
+/// This models the visit state for dependency keys in a `Cargo.toml`.
+///
+/// Dependencies can be specified as:
+///
+/// ```toml
+/// [dependencies]
+/// dep1 = "0.2"
+///
+/// [build-dependencies]
+/// dep2 = "0.3"
+///
+/// [dev-dependencies]
+/// dep3 = "0.4"
+///
+/// [target.'cfg(windows)'.dependencies]
+/// dep4 = "0.5"
+///
+/// # and target build- and dev-dependencies
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum VisitState {
+    /// Represents the root of the table.
+    Root,
+    /// Represents "dependencies", "build-dependencies" or "dev-dependencies", or the target
+    /// forms of these.
+    Dependencies,
+    /// A table within dependencies.
+    SubDependencies,
+    /// Represents "target".
+    Target,
+    /// "target.[TARGET]".
+    TargetWithSpec,
+    /// Represents some other state.
+    Other,
+}
+
+impl VisitState {
+    /// Figures out the next visit state, given the current state and the given key.
+    fn descend(self, key: &str) -> Self {
+        match (self, key) {
+            (
+                VisitState::Root | VisitState::TargetWithSpec,
+                "dependencies" | "build-dependencies" | "dev-dependencies",
+            ) => VisitState::Dependencies,
+            (VisitState::Root, "target") => VisitState::Target,
+            (VisitState::Root | VisitState::TargetWithSpec, _) => VisitState::Other,
+            (VisitState::Target, _) => VisitState::TargetWithSpec,
+            (VisitState::Dependencies, _) => VisitState::SubDependencies,
+            (VisitState::SubDependencies, _) => VisitState::SubDependencies,
+            (VisitState::Other, _) => VisitState::Other,
+        }
+    }
+}
+
+/// Normalize all dependency tables into the format:
+///
+/// ```toml
+/// [dependencies]
+/// dep = { version = "1.0", features = ["foo", "bar"], ... }
+/// ```
+///
+/// leaving other tables untouched.
+#[derive(Debug)]
+struct NormalizeDependencyTablesVisitor {
+    state: VisitState,
+}
+
+impl VisitMut for NormalizeDependencyTablesVisitor {
+    fn visit_table_mut(&mut self, node: &mut Table) {
+        visit_table_mut(self, node);
+
+        // The conversion from regular tables into inline ones might leave some explicit parent
+        // tables hanging, so convert them to implicit.
+        if matches!(self.state, VisitState::Target | VisitState::TargetWithSpec) {
+            node.set_implicit(true);
+        }
+    }
+
+    fn visit_table_like_kv_mut(&mut self, mut key: KeyMut<'_>, node: &mut Item) {
+        let old_state = self.state;
+
+        // Figure out the next state given the key.
+        self.state = self.state.descend(key.get());
+
+        match self.state {
+            VisitState::Target | VisitState::TargetWithSpec | VisitState::Dependencies => {
+                // Top-level dependency row, or above: turn inline tables into regular ones.
+                if let Item::Value(Value::InlineTable(inline_table)) = node {
+                    let inline_table = std::mem::replace(inline_table, InlineTable::new());
+                    let table = inline_table.into_table();
+                    key.fmt();
+                    *node = Item::Table(table);
+                }
+            }
+            VisitState::SubDependencies => {
+                // Individual dependency: turn regular tables into inline ones.
+                if let Item::Table(table) = node {
+                    // Turn the table into an inline table.
+                    let table = std::mem::replace(table, Table::new());
+                    let inline_table = table.into_inline_table();
+                    key.fmt();
+                    *node = Item::Value(Value::InlineTable(inline_table));
+                }
+            }
+            _ => {}
+        }
+
+        // Recurse further into the document tree.
+        visit_table_like_kv_mut(self, key, node);
+
+        // Restore the old state after it's done.
+        self.state = old_state;
+    }
+
+    fn visit_array_mut(&mut self, node: &mut Array) {
+        // Format any arrays within dependencies to be on the same line.
+        if matches!(
+            self.state,
+            VisitState::Dependencies | VisitState::SubDependencies
+        ) {
+            node.fmt();
+        }
+    }
+}
+
+/// This is the input provided to visit_mut_example.
+static INPUT: &str = r#"
+[package]
+name = "my-package"
+
+[package.metadata.foo]
+bar = 42
+
+[dependencies]
+atty = "0.2"
+cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
+
+[dependencies.pretty_env_logger]
+version = "0.4"
+optional = true
+
+[target.'cfg(windows)'.dependencies]
+fwdansi = "1.1.0"
+
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = [
+"handleapi",
+"jobapi",
+]
+
+[target.'cfg(unix)']
+dev-dependencies = { miniz_oxide = "0.5" }
+
+[dev-dependencies.cargo-test-macro]
+path = "crates/cargo-test-macro"
+
+[build-dependencies.flate2]
+version = "0.4"
+"#;
+
+/// This is the output produced by visit_mut_example.
+#[cfg(test)]
+static VISIT_MUT_OUTPUT: &str = r#"
+[package]
+name = "my-package"
+
+[package.metadata.foo]
+bar = 42
+
+[dependencies]
+atty = "0.2"
+cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
+pretty_env_logger = { version = "0.4", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+fwdansi = "1.1.0"
+winapi = { version = "0.3", features = ["handleapi", "jobapi"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+miniz_oxide = "0.5"
+
+[dev-dependencies]
+cargo-test-macro = { path = "crates/cargo-test-macro" }
+
+[build-dependencies]
+flate2 = { version = "0.4" }
+"#;
+
+fn visit_mut_example(document: &mut Document) {
+    let mut visitor = NormalizeDependencyTablesVisitor {
+        state: VisitState::Root,
+    };
+
+    visitor.visit_document_mut(document);
+}
+
+fn main() {
+    let mut document: Document = INPUT.parse().expect("input is valid TOML");
+
+    println!("** visit_mut example");
+    visit_mut_example(&mut document);
+    println!("{}", document);
+}
+
+#[cfg(test)]
+#[test]
+fn visit_mut_correct() {
+    let mut document: Document = INPUT.parse().expect("input is valid TOML");
+
+    visit_mut_example(&mut document);
+    assert_eq!(format!("{}", document), VISIT_MUT_OUTPUT);
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -368,4 +368,7 @@ fn decorate_array(array: &mut Array) {
             value.decorate(DEFAULT_VALUE_DECOR.0, DEFAULT_VALUE_DECOR.1);
         }
     }
+    // Since everything is now on the same line, remove trailing commas and whitespace.
+    array.set_trailing_comma(false);
+    array.set_trailing("");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub mod de;
 #[cfg(feature = "serde")]
 pub mod ser;
 
+pub mod visit;
 pub mod visit_mut;
 
 pub use crate::array::{Array, ArrayIntoIter, ArrayIter, ArrayIterMut};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,8 @@ pub mod de;
 #[cfg(feature = "serde")]
 pub mod ser;
 
+pub mod visit_mut;
+
 pub use crate::array::{Array, ArrayIntoIter, ArrayIter, ArrayIterMut};
 pub use crate::array_of_tables::{
     ArrayOfTables, ArrayOfTablesIntoIter, ArrayOfTablesIter, ArrayOfTablesIterMut,

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -1,0 +1,236 @@
+#![allow(missing_docs)]
+
+//! Document tree traversal to walk a shared borrow of a document tree.
+//!
+//! Each method of the [`Visit`] trait is a hook that can be overridden
+//! to customize the behavior when mutating the corresponding type of node.
+//! By default, every method recursively visits the substructure of the
+//! input by invoking the right visitor method of each of its fields.
+//!
+//! ```
+//! # use toml_edit::{Item, ArrayOfTables, Table, Value};
+//!
+//! pub trait Visit<'doc> {
+//!     /* ... */
+//!
+//!     fn visit_item(&mut self, i: &'doc Item) {
+//!         visit_item(self, i);
+//!     }
+//!
+//!     /* ... */
+//!     # fn visit_value(&mut self, i: &'doc Value);
+//!     # fn visit_table(&mut self, i: &'doc Table);
+//!     # fn visit_array_of_tables(&mut self, i: &'doc ArrayOfTables);
+//! }
+//!
+//! pub fn visit_item<'doc, V>(v: &mut V, node: &'doc Item)
+//! where
+//!     V: Visit<'doc> + ?Sized,
+//! {
+//!     match node {
+//!         Item::None => {}
+//!         Item::Value(value) => v.visit_value(value),
+//!         Item::Table(table) => v.visit_table(table),
+//!         Item::ArrayOfTables(array) => v.visit_array_of_tables(array),
+//!     }
+//! }
+//! ```
+//!
+//! The API is modeled after [`syn::visit`](https://docs.rs/syn/1/syn/visit).
+//!
+//! # Examples
+//!
+//! This visitor stores every string in the document.
+//!
+//! ```
+//! # use toml_edit::*;
+//! use toml_edit::visit::*;
+//!
+//! #[derive(Default)]
+//! struct StringCollector<'doc> {
+//!     strings: Vec<&'doc str>,
+//! }
+//!
+//! impl<'doc> Visit<'doc> for StringCollector<'doc> {
+//!     fn visit_string(&mut self, node: &'doc Formatted<String>) {
+//!          self.strings.push(node.value().as_str());
+//!     }
+//! }
+//!
+//! let input = r#"
+//! laputa = "sky-castle"
+//! the-force = { value = "surrounds-you" }
+//! "#;
+//!
+//! let mut document: Document = input.parse().unwrap();
+//! let mut visitor = StringCollector::default();
+//! visitor.visit_document(&document);
+//!
+//! assert_eq!(visitor.strings, vec!["sky-castle", "surrounds-you"]);
+//! ```
+//!
+//! For a more complex example where the visitor has internal state, see `examples/visit.rs`
+//! [on GitHub](https://github.com/ordian/toml_edit/blob/master/examples/visit.rs).
+
+use crate::{
+    Array, ArrayOfTables, Datetime, Document, Formatted, InlineTable, Item, Table, TableLike, Value,
+};
+
+/// Document tree traversal to mutate an exclusive borrow of a document tree in-place.
+///
+/// See the [module documentation](self) for details.
+pub trait Visit<'doc> {
+    fn visit_document(&mut self, node: &'doc Document) {
+        visit_document(self, node);
+    }
+
+    fn visit_item(&mut self, node: &'doc Item) {
+        visit_item(self, node);
+    }
+
+    fn visit_table(&mut self, node: &'doc Table) {
+        visit_table(self, node);
+    }
+
+    fn visit_inline_table(&mut self, node: &'doc InlineTable) {
+        visit_inline_table(self, node)
+    }
+
+    fn visit_table_like(&mut self, node: &'doc dyn TableLike) {
+        visit_table_like(self, node);
+    }
+
+    fn visit_table_like_kv(&mut self, key: &'doc str, node: &'doc Item) {
+        visit_table_like_kv(self, key, node);
+    }
+
+    fn visit_array(&mut self, node: &'doc Array) {
+        visit_array(self, node);
+    }
+
+    fn visit_array_of_tables(&mut self, node: &'doc ArrayOfTables) {
+        visit_array_of_tables(self, node);
+    }
+
+    fn visit_value(&mut self, node: &'doc Value) {
+        visit_value(self, node);
+    }
+
+    fn visit_boolean(&mut self, node: &'doc Formatted<bool>) {
+        visit_boolean(self, node)
+    }
+
+    fn visit_datetime(&mut self, node: &'doc Formatted<Datetime>) {
+        visit_datetime(self, node);
+    }
+
+    fn visit_float(&mut self, node: &'doc Formatted<f64>) {
+        visit_float(self, node)
+    }
+
+    fn visit_integer(&mut self, node: &'doc Formatted<i64>) {
+        visit_integer(self, node)
+    }
+
+    fn visit_string(&mut self, node: &'doc Formatted<String>) {
+        visit_string(self, node)
+    }
+}
+
+pub fn visit_document<'doc, V>(v: &mut V, node: &'doc Document)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    v.visit_table(node.as_table());
+}
+
+pub fn visit_item<'doc, V>(v: &mut V, node: &'doc Item)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    match node {
+        Item::None => {}
+        Item::Value(value) => v.visit_value(value),
+        Item::Table(table) => v.visit_table(table),
+        Item::ArrayOfTables(array) => v.visit_array_of_tables(array),
+    }
+}
+
+pub fn visit_table<'doc, V>(v: &mut V, node: &'doc Table)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    v.visit_table_like(node)
+}
+
+pub fn visit_inline_table<'doc, V>(v: &mut V, node: &'doc InlineTable)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    v.visit_table_like(node)
+}
+
+pub fn visit_table_like<'doc, V>(v: &mut V, node: &'doc dyn TableLike)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    for (key, item) in node.iter() {
+        v.visit_table_like_kv(key, item)
+    }
+}
+
+pub fn visit_table_like_kv<'doc, V>(v: &mut V, _key: &'doc str, node: &'doc Item)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    v.visit_item(node)
+}
+
+pub fn visit_array<'doc, V>(v: &mut V, node: &'doc Array)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    for value in node.iter() {
+        v.visit_value(value);
+    }
+}
+
+pub fn visit_array_of_tables<'doc, V>(v: &mut V, node: &'doc ArrayOfTables)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    for table in node.iter() {
+        v.visit_table(table);
+    }
+}
+
+pub fn visit_value<'doc, V>(v: &mut V, node: &'doc Value)
+where
+    V: Visit<'doc> + ?Sized,
+{
+    match node {
+        Value::String(s) => v.visit_string(s),
+        Value::Integer(i) => v.visit_integer(i),
+        Value::Float(f) => v.visit_float(f),
+        Value::Boolean(b) => v.visit_boolean(b),
+        Value::Datetime(dt) => v.visit_datetime(dt),
+        Value::Array(array) => v.visit_array(array),
+        Value::InlineTable(table) => v.visit_inline_table(table),
+    }
+}
+
+macro_rules! empty_visit {
+    ($name: ident, $t: ty) => {
+        fn $name<'doc, V>(_v: &mut V, _node: &'doc $t)
+        where
+            V: Visit<'doc> + ?Sized,
+        {
+        }
+    };
+}
+
+empty_visit!(visit_boolean, Formatted<bool>);
+empty_visit!(visit_datetime, Formatted<Datetime>);
+empty_visit!(visit_float, Formatted<f64>);
+empty_visit!(visit_integer, Formatted<i64>);
+empty_visit!(visit_string, Formatted<String>);

--- a/src/visit_mut.rs
+++ b/src/visit_mut.rs
@@ -1,0 +1,252 @@
+#![allow(missing_docs)]
+
+//! Document tree traversal to mutate an exclusive borrow of a document tree in place.
+//!
+//!
+//! Each method of the [`VisitMut`] trait is a hook that can be overridden
+//! to customize the behavior when mutating the corresponding type of node.
+//! By default, every method recursively visits the substructure of the
+//! input by invoking the right visitor method of each of its fields.
+//!
+//! ```
+//! # use toml_edit::{Item, ArrayOfTables, Table, Value};
+//!
+//! pub trait VisitMut {
+//!     /* ... */
+//!
+//!     fn visit_item_mut(&mut self, i: &mut Item) {
+//!         visit_item_mut(self, i);
+//!     }
+//!
+//!     /* ... */
+//!     # fn visit_value_mut(&mut self, i: &mut Value);
+//!     # fn visit_table_mut(&mut self, i: &mut Table);
+//!     # fn visit_array_of_tables_mut(&mut self, i: &mut ArrayOfTables);
+//! }
+//!
+//! pub fn visit_item_mut<V>(v: &mut V, node: &mut Item)
+//! where
+//!     V: VisitMut + ?Sized,
+//! {
+//!     match node {
+//!         Item::None => {}
+//!         Item::Value(value) => v.visit_value_mut(value),
+//!         Item::Table(table) => v.visit_table_mut(table),
+//!         Item::ArrayOfTables(array) => v.visit_array_of_tables_mut(array),
+//!     }
+//! }
+//! ```
+//!
+//! The API is modeled after [`syn::visit_mut`](https://docs.rs/syn/1/syn/visit_mut).
+//!
+//! # Examples
+//!
+//! This visitor replaces every floating point value with its decimal string representation, to
+//! 2 decimal points.
+//!
+//! ```
+//! # use toml_edit::*;
+//! use toml_edit::visit_mut::*;
+//!
+//! struct FloatToString;
+//!
+//! impl VisitMut for FloatToString {
+//!     fn visit_value_mut(&mut self, node: &mut Value) {
+//!         if let Value::Float(f) = node {
+//!             // Convert the float to a string.
+//!             let mut s = Formatted::new(format!("{:.2}", f.value()));
+//!             // Copy over the formatting.
+//!             std::mem::swap(s.decor_mut(), f.decor_mut());
+//!             *node = Value::String(s);
+//!         }
+//!         // Most of the time, you will also need to call the default implementation to recurse
+//!         // further down the document tree.
+//!         visit_value_mut(self, node);
+//!     }
+//! }
+//!
+//! let input = r#"
+//! banana = 3.26
+//! table = { apple = 4.5 }
+//! "#;
+//!
+//! let mut document: Document = input.parse().unwrap();
+//! let mut visitor = FloatToString;
+//! visitor.visit_document_mut(&mut document);
+//!
+//! let output = r#"
+//! banana = "3.26"
+//! table = { apple = "4.50" }
+//! "#;
+//!
+//! assert_eq!(format!("{}", document), output);
+//! ```
+//!
+//! For a more complex example where the visitor has internal state, see `examples/visit.rs`
+//! [on GitHub](https://github.com/ordian/toml_edit/blob/master/examples/visit.rs).
+
+use crate::{
+    Array, ArrayOfTables, Datetime, Document, Formatted, InlineTable, Item, KeyMut, Table,
+    TableLike, Value,
+};
+
+/// Document tree traversal to mutate an exclusive borrow of a document tree in-place.
+///
+/// See the [module documentation](self) for details.
+pub trait VisitMut {
+    fn visit_document_mut(&mut self, node: &mut Document) {
+        visit_document_mut(self, node);
+    }
+
+    fn visit_item_mut(&mut self, node: &mut Item) {
+        visit_item_mut(self, node);
+    }
+
+    fn visit_table_mut(&mut self, node: &mut Table) {
+        visit_table_mut(self, node);
+    }
+
+    fn visit_inline_table_mut(&mut self, node: &mut InlineTable) {
+        visit_inline_table_mut(self, node)
+    }
+
+    /// [`visit_table_mut`](Self::visit_table_mut) and
+    /// [`visit_inline_table_mut`](Self::visit_inline_table_mut) both recurse into this method.
+    fn visit_table_like_mut(&mut self, node: &mut dyn TableLike) {
+        visit_table_like_mut(self, node);
+    }
+
+    fn visit_table_like_kv_mut(&mut self, key: KeyMut<'_>, node: &mut Item) {
+        visit_table_like_kv_mut(self, key, node);
+    }
+
+    fn visit_array_mut(&mut self, node: &mut Array) {
+        visit_array_mut(self, node);
+    }
+
+    fn visit_array_of_tables_mut(&mut self, node: &mut ArrayOfTables) {
+        visit_array_of_tables_mut(self, node);
+    }
+
+    fn visit_value_mut(&mut self, node: &mut Value) {
+        visit_value_mut(self, node);
+    }
+
+    fn visit_boolean_mut(&mut self, node: &mut Formatted<bool>) {
+        visit_boolean_mut(self, node)
+    }
+
+    fn visit_datetime_mut(&mut self, node: &mut Formatted<Datetime>) {
+        visit_datetime_mut(self, node);
+    }
+
+    fn visit_float_mut(&mut self, node: &mut Formatted<f64>) {
+        visit_float_mut(self, node)
+    }
+
+    fn visit_integer_mut(&mut self, node: &mut Formatted<i64>) {
+        visit_integer_mut(self, node)
+    }
+
+    fn visit_string_mut(&mut self, node: &mut Formatted<String>) {
+        visit_string_mut(self, node)
+    }
+}
+
+pub fn visit_document_mut<V>(v: &mut V, node: &mut Document)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_table_mut(node.as_table_mut());
+}
+
+pub fn visit_item_mut<V>(v: &mut V, node: &mut Item)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        Item::None => {}
+        Item::Value(value) => v.visit_value_mut(value),
+        Item::Table(table) => v.visit_table_mut(table),
+        Item::ArrayOfTables(array) => v.visit_array_of_tables_mut(array),
+    }
+}
+
+pub fn visit_table_mut<V>(v: &mut V, node: &mut Table)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_table_like_mut(node);
+}
+
+pub fn visit_inline_table_mut<V>(v: &mut V, node: &mut InlineTable)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_table_like_mut(node);
+}
+
+pub fn visit_table_like_mut<V>(v: &mut V, node: &mut dyn TableLike)
+where
+    V: VisitMut + ?Sized,
+{
+    for (key, item) in node.iter_mut() {
+        v.visit_table_like_kv_mut(key, item);
+    }
+}
+
+pub fn visit_table_like_kv_mut<V>(v: &mut V, _key: KeyMut<'_>, node: &mut Item)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_item_mut(node)
+}
+
+pub fn visit_array_mut<V>(v: &mut V, node: &mut Array)
+where
+    V: VisitMut + ?Sized,
+{
+    for value in node.iter_mut() {
+        v.visit_value_mut(value);
+    }
+}
+
+pub fn visit_array_of_tables_mut<V>(v: &mut V, node: &mut ArrayOfTables)
+where
+    V: VisitMut + ?Sized,
+{
+    for table in node.iter_mut() {
+        v.visit_table_mut(table);
+    }
+}
+
+pub fn visit_value_mut<V>(v: &mut V, node: &mut Value)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        Value::String(s) => v.visit_string_mut(s),
+        Value::Integer(i) => v.visit_integer_mut(i),
+        Value::Float(f) => v.visit_float_mut(f),
+        Value::Boolean(b) => v.visit_boolean_mut(b),
+        Value::Datetime(dt) => v.visit_datetime_mut(dt),
+        Value::Array(array) => v.visit_array_mut(array),
+        Value::InlineTable(table) => v.visit_inline_table_mut(table),
+    }
+}
+
+macro_rules! empty_visit_mut {
+    ($name: ident, $t: ty) => {
+        fn $name<V>(_v: &mut V, _node: &mut $t)
+        where
+            V: VisitMut + ?Sized,
+        {
+        }
+    };
+}
+
+empty_visit_mut!(visit_boolean_mut, Formatted<bool>);
+empty_visit_mut!(visit_datetime_mut, Formatted<Datetime>);
+empty_visit_mut!(visit_float_mut, Formatted<f64>);
+empty_visit_mut!(visit_integer_mut, Formatted<i64>);
+empty_visit_mut!(visit_string_mut, Formatted<String>);

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -627,6 +627,31 @@ fn test_remove_from_array() {
     );
 }
 
+#[test]
+fn test_format_array() {
+    given(
+        r#"
+    a = [
+      1,
+            "2",
+      3.0,
+    ]
+    "#,
+    )
+    .running(|root| {
+        for (_, v) in root.iter_mut() {
+            if let Item::Value(Value::Array(array)) = v {
+                array.fmt();
+            }
+        }
+    })
+    .produces_display(
+        r#"
+    a = [1, "2", 3.0]
+    "#,
+    );
+}
+
 macro_rules! as_inline_table {
     ($entry:ident) => {{
         assert!($entry.is_value());


### PR DESCRIPTION
This is modeled after the `syn::visit` and `syn::visit_mut` APIs. See discussion in https://github.com/ordian/toml_edit/issues/192#issuecomment-974742445 for what prompted me to write this.

Also include some nontrivial examples for custom formatting.

One thing that immediately occurs to me is that we could easily provide a recursive formatter based on this (which would strengthen the argument for it being available unconditionally).