### PR TITLE
fix: Clear decor when converting types

### DIFF
--- a/src/array_of_tables.rs
+++ b/src/array_of_tables.rs
@@ -26,7 +26,9 @@ impl ArrayOfTables {
         for value in self.values.iter_mut() {
             value.make_value();
         }
-        Array::with_vec(self.values)
+        let mut a = Array::with_vec(self.values);
+        a.fmt();
+        a
     }
 }
 

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -36,7 +36,9 @@ impl InlineTable {
 
     /// Convert to a table
     pub fn into_table(self) -> Table {
-        Table::with_pairs(self.items)
+        let mut t = Table::with_pairs(self.items);
+        t.fmt();
+        t
     }
 }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -116,8 +116,14 @@ impl Item {
         match self {
             Item::None => Err(self),
             Item::Value(v) => Ok(v),
-            Item::Table(v) => Ok(Value::InlineTable(v.into_inline_table())),
-            Item::ArrayOfTables(v) => Ok(Value::Array(v.into_array())),
+            Item::Table(v) => {
+                let v = v.into_inline_table();
+                Ok(Value::InlineTable(v))
+            }
+            Item::ArrayOfTables(v) => {
+                let v = v.into_array();
+                Ok(Value::Array(v))
+            }
         }
     }
     /// In-place convert to a value

--- a/src/table.rs
+++ b/src/table.rs
@@ -50,7 +50,9 @@ impl Table {
         for (_, kv) in self.items.iter_mut() {
             kv.value.make_value();
         }
-        InlineTable::with_pairs(self.items)
+        let mut t = InlineTable::with_pairs(self.items);
+        t.fmt();
+        t
     }
 }
 

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -1,0 +1,80 @@
+use pretty_assertions::assert_eq;
+
+use toml_edit::{Document, Item, Value};
+
+#[test]
+fn table_into_inline() {
+    let toml = r#"
+[table]
+string = "value"
+array = [1, 2, 3]
+inline = { "1" = 1, "2" = 2 }
+
+[table.child]
+other = "world"
+"#;
+    let mut doc = toml.parse::<Document>().unwrap();
+
+    doc.get_mut("table").unwrap().make_value();
+
+    let actual = doc.to_string();
+    // `table=` is because we didn't re-format the table key, only the value
+    let expected = r#"table= { string = "value", array = [1, 2, 3], inline = { "1" = 1, "2" = 2 }, child = { other = "world" } }
+"#;
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn inline_table_to_table() {
+    let toml = r#"table = { string = "value", array = [1, 2, 3], inline = { "1" = 1, "2" = 2 }, child = { other = "world" } }
+"#;
+    let mut doc = toml.parse::<Document>().unwrap();
+
+    let t = doc.remove("table").unwrap();
+    let t = match t {
+        Item::Value(Value::InlineTable(t)) => t,
+        _ => unreachable!("Unexpected {:?}", t),
+    };
+    let t = t.into_table();
+    doc.insert("table", Item::Table(t));
+
+    let actual = doc.to_string();
+    let expected = r#"
+[table]
+string = "value"
+array = [1, 2, 3]
+inline = { "1" = 1, "2" = 2 }
+child = { other = "world" }
+"#;
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn array_of_tables_to_array() {
+    let toml = r#"
+[[table]]
+string = "value"
+array = [1, 2, 3]
+inline = { "1" = 1, "2" = 2 }
+
+[table.child]
+other = "world"
+
+[[table]]
+string = "value"
+array = [1, 2, 3]
+inline = { "1" = 1, "2" = 2 }
+
+[table.child]
+other = "world"
+"#;
+    let mut doc = toml.parse::<Document>().unwrap();
+
+    doc.get_mut("table").unwrap().make_value();
+
+    let actual = doc.to_string();
+    // `table=` is because we didn't re-format the table key, only the value
+    let expected = r#"table= [{ string = "value", array = [1, 2, 3], inline = { "1" = 1, "2" = 2 }, child = { other = "world" } }, { string = "value", array = [1, 2, 3], inline = { "1" = 1, "2" = 2 }, child = { other = "world" } }]
+"#;
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
The likelihood of a user changing from Item to Value to Item and wanting
the decor roundtripped is extremely low.  The likelihood the user will
do Item to Value and *not* want the original formatting is extremely
high.

Let's favor the more likely outcome.