### PR TITLE
fix!: Allow people iterating to modify the key

### DIFF
--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 use crate::key::Key;
 use crate::repr::Decor;
 use crate::table::{Iter, IterMut, KeyValuePairs, TableKeyValue, TableLike};
-use crate::{InternalString, Item, Table, Value};
+use crate::{InternalString, Item, KeyMut, Table, Value};
 
 /// Type representing a TOML inline table,
 /// payload of the `Value::InlineTable` variant
@@ -141,7 +141,7 @@ impl InlineTable {
             self.items
                 .iter_mut()
                 .filter(|(_, kv)| kv.value.is_value())
-                .map(|(k, kv)| (&k[..], kv.value.as_value_mut().unwrap())),
+                .map(|(_, kv)| (kv.key.as_mut(), kv.value.as_value_mut().unwrap())),
         )
     }
 
@@ -345,7 +345,7 @@ pub type InlineTableIntoIter = Box<dyn Iterator<Item = (InternalString, Value)>>
 /// An iterator type over key/value pairs of an inline table.
 pub type InlineTableIter<'a> = Box<dyn Iterator<Item = (&'a str, &'a Value)> + 'a>;
 /// A mutable iterator type over key/value pairs of an inline table.
-pub type InlineTableIterMut<'a> = Box<dyn Iterator<Item = (&'a str, &'a mut Value)> + 'a>;
+pub type InlineTableIterMut<'a> = Box<dyn Iterator<Item = (KeyMut<'a>, &'a mut Value)> + 'a>;
 
 impl TableLike for InlineTable {
     fn iter(&self) -> Iter<'_> {
@@ -355,7 +355,7 @@ impl TableLike for InlineTable {
         Box::new(
             self.items
                 .iter_mut()
-                .map(|(key, kv)| (&key[..], &mut kv.value)),
+                .map(|(_, kv)| (kv.key.as_mut(), &mut kv.value)),
         )
     }
     fn get<'s>(&'s self, key: &str) -> Option<&'s Item> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -111,6 +111,35 @@ impl Key {
     }
 }
 
+impl std::ops::Deref for Key {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.get()
+    }
+}
+
+impl<'s> PartialEq<str> for Key {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        PartialEq::eq(self.get(), other)
+    }
+}
+
+impl<'s> PartialEq<&'s str> for Key {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        PartialEq::eq(self.get(), *other)
+    }
+}
+
+impl<'s> PartialEq<String> for Key {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        PartialEq::eq(self.get(), other.as_str())
+    }
+}
+
 impl std::fmt::Display for Key {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         crate::encode::Encode::encode(self, f, ("", ""))

--- a/src/key.rs
+++ b/src/key.rs
@@ -59,6 +59,11 @@ impl Key {
         self
     }
 
+    /// Access a mutable proxy for the `Key`.
+    pub fn as_mut(&mut self) -> KeyMut<'_> {
+        KeyMut { key: self }
+    }
+
     /// Returns the parsed key value.
     pub fn get(&self) -> &str {
         &self.key
@@ -197,5 +202,73 @@ impl From<InternalString> for Key {
 impl From<Key> for InternalString {
     fn from(key: Key) -> InternalString {
         key.key
+    }
+}
+
+/// A mutable reference to a `Key`
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct KeyMut<'k> {
+    key: &'k mut Key,
+}
+
+impl<'k> KeyMut<'k> {
+    /// Returns the parsed key value.
+    pub fn get(&self) -> &str {
+        self.key.get()
+    }
+
+    /// Returns the key raw representation.
+    pub fn to_repr(&self) -> Cow<Repr> {
+        self.key.to_repr()
+    }
+
+    /// Returns the surrounding whitespace
+    pub fn decor_mut(&mut self) -> &mut Decor {
+        self.key.decor_mut()
+    }
+
+    /// Returns the surrounding whitespace
+    pub fn decor(&self) -> &Decor {
+        self.key.decor()
+    }
+
+    /// Auto formats the key.
+    pub fn fmt(&mut self) {
+        self.key.fmt()
+    }
+}
+
+impl<'k> std::ops::Deref for KeyMut<'k> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.get()
+    }
+}
+
+impl<'s> PartialEq<str> for KeyMut<'s> {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        PartialEq::eq(self.get(), other)
+    }
+}
+
+impl<'s> PartialEq<&'s str> for KeyMut<'s> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        PartialEq::eq(self.get(), *other)
+    }
+}
+
+impl<'s> PartialEq<String> for KeyMut<'s> {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        PartialEq::eq(self.get(), other.as_str())
+    }
+}
+
+impl<'k> std::fmt::Display for KeyMut<'k> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.key, f)
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -89,6 +89,7 @@ impl Key {
     /// Auto formats the key.
     pub fn fmt(&mut self) {
         self.repr = Some(to_key_repr(&self.key));
+        self.decor.clear();
     }
 
     fn try_parse(s: &str) -> Result<Key, parser::TomlError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub use crate::inline_table::{
 };
 pub use crate::internal_string::InternalString;
 pub use crate::item::{array, table, value, Item};
-pub use crate::key::Key;
+pub use crate::key::{Key, KeyMut};
 pub use crate::parser::TomlError;
 pub use crate::repr::{Decor, Formatted, Repr};
 pub use crate::table::{

--- a/src/table.rs
+++ b/src/table.rs
@@ -5,7 +5,7 @@ use indexmap::map::IndexMap;
 use crate::key::Key;
 use crate::repr::Decor;
 use crate::value::DEFAULT_VALUE_DECOR;
-use crate::{InlineTable, InternalString, Item, Value};
+use crate::{InlineTable, InternalString, Item, KeyMut, Value};
 
 /// Type representing a TOML non-inline table
 #[derive(Clone, Debug, Default)]
@@ -201,7 +201,7 @@ impl Table {
         Box::new(
             self.items
                 .iter_mut()
-                .map(|(key, kv)| (&key[..], &mut kv.value)),
+                .map(|(_, kv)| (kv.key.as_mut(), &mut kv.value)),
         )
     }
 
@@ -401,7 +401,7 @@ pub type IntoIter = Box<dyn Iterator<Item = (InternalString, Item)>>;
 /// An iterator type over `Table`'s key/value pairs.
 pub type Iter<'a> = Box<dyn Iterator<Item = (&'a str, &'a Item)> + 'a>;
 /// A mutable iterator type over `Table`'s key/value pairs.
-pub type IterMut<'a> = Box<dyn Iterator<Item = (&'a str, &'a mut Item)> + 'a>;
+pub type IterMut<'a> = Box<dyn Iterator<Item = (KeyMut<'a>, &'a mut Item)> + 'a>;
 
 /// This trait represents either a `Table`, or an `InlineTable`.
 pub trait TableLike: crate::private::Sealed {


### PR DESCRIPTION
By providing a `KeyMut`, we can safely allow people to modify keys while
iterating.  We've extending the interface to allow greater interop to
reduce pain for people who don't need this.

BREAKING CHANGE: `IterMut`s for table-likes now use a `KeyMut` key
instead of `&str`.