### PR TITLE
fix: Don't confuse trailing whitespace as date/time separator

### DIFF
--- a/src/parser/datetime.rs
+++ b/src/parser/datetime.rs
@@ -19,7 +19,10 @@ parse!(date_time() -> Datetime, {
         (
             full_date(),
             optional((
-                satisfy(is_time_delim),
+                attempt((
+                    satisfy(is_time_delim),
+                    look_ahead(time_hour())
+                )),
                 partial_time(),
                 optional(time_offset()),
             ))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -620,6 +620,8 @@ key = "value"
 "#,
             r#"hello.world = "a"
 "#,
+            r#"foo = 1979-05-27 # Comment
+"#,
         ];
         for document in &documents {
             let doc = TomlParser::parse(document.as_bytes());

--- a/tests/test_invalid.rs
+++ b/tests/test_invalid.rs
@@ -1,13 +1,14 @@
 use toml_edit::Document;
 
+#[track_caller]
 fn run(toml: &str, msg: &str) {
     let doc = toml.parse::<Document>();
-    assert!(doc.is_err());
 
     let err = match doc {
         Err(e) => e.to_string(),
-        _ => unreachable!(""),
+        _ => unreachable!("must fail"),
     };
+    dbg!(&err);
     assert!(err.contains(msg));
 }
 


### PR DESCRIPTION
Fixes #269