### PR TITLE
fix!: Make `Key::from_str` only accept `Display`s output

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -158,11 +158,7 @@ impl FromStr for Key {
     /// if fails, tries as basic quoted key (surrounds with "")
     /// and then literal quoted key (surrounds with '')
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let basic = format!("\"{}\"", s);
-        let literal = format!("'{}'", s);
         Key::try_parse(s)
-            .or_else(|_| Key::try_parse(&basic))
-            .or_else(|_| Key::try_parse(&literal))
     }
 }
 

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -31,7 +31,7 @@ const ARRAY_TABLE_CLOSE: &[u8] = b"]]";
 toml_parser!(std_table, parser, {
     (
         between(byte(STD_TABLE_OPEN), byte(STD_TABLE_CLOSE), key()),
-        line_trailing().and_then(|t| std::str::from_utf8(t)),
+        line_trailing().and_then(std::str::from_utf8),
     )
         .and_then(|(h, t)| parser.borrow_mut().deref_mut().on_std_header(h, t))
 });
@@ -42,7 +42,7 @@ toml_parser!(std_table, parser, {
 toml_parser!(array_table, parser, {
     (
         between(range(ARRAY_TABLE_OPEN), range(ARRAY_TABLE_CLOSE), key()),
-        line_trailing().and_then(|t| std::str::from_utf8(t)),
+        line_trailing().and_then(std::str::from_utf8),
     )
         .and_then(|(h, t)| parser.borrow_mut().deref_mut().on_array_header(h, t))
 });

--- a/tests/easy_encoder.rs
+++ b/tests/easy_encoder.rs
@@ -82,5 +82,5 @@ fn from_table(
 fn from_array(
     decoded: &[toml_test_harness::Decoded],
 ) -> Result<toml_edit::easy::value::Array, toml_test_harness::Error> {
-    decoded.iter().map(|v| from_decoded(v)).collect()
+    decoded.iter().map(from_decoded).collect()
 }

--- a/tests/encoder.rs
+++ b/tests/encoder.rs
@@ -106,5 +106,5 @@ fn from_table(
 fn from_array(
     decoded: &[toml_test_harness::Decoded],
 ) -> Result<toml_edit::Array, toml_test_harness::Error> {
-    decoded.iter().map(|v| from_decoded(v)).collect()
+    decoded.iter().map(from_decoded).collect()
 }


### PR DESCRIPTION
I remember wanting to remove this before and had problems.  It looks
like those have since been addressed (I think with changes to repr).

Before, we were taking any string and trying to infer what its repr
would be.

Now we only parse actualy dotted keys.

This will hopefully help with rust-lang/cargo#10176

BREAKING CHANGE: `Key::from_str` will accept fewer values and will
return slightly different errors.