### PR TITLE
feat: Supprt parsing dotted keys

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,7 +17,8 @@ mod value;
 
 pub use self::errors::TomlError;
 pub(crate) use self::key::is_unquoted_char;
-pub(crate) use self::key::simple_key as key_parser;
+pub(crate) use self::key::key as key_path;
+pub(crate) use self::key::simple_key;
 pub(crate) use self::value::value as value_parser;
 
 use self::table::duplicate_key;


### PR DESCRIPTION
We support parsing a lot of expressions to help users to edit their toml
document from real world code.  One thing that was missing was dotted
key parsing.

Also, this will hopefully help with rust-lang/cargo#10176