### PR TITLE
fix(serde): Use correct trait bound

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -3,7 +3,7 @@
 //! This module contains all the Serde support for deserializing TOML documents into Rust structures.
 
 use itertools::Itertools;
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
 mod array;
 mod inline_table;
@@ -69,7 +69,7 @@ impl std::error::Error for Error {}
 /// Convert a value into `T`.
 pub fn from_str<T>(s: &'_ str) -> Result<T, Error>
 where
-    T: Deserialize<'static>,
+    T: DeserializeOwned,
 {
     let d = s.parse::<crate::Document>()?;
     from_document(d)
@@ -78,7 +78,7 @@ where
 /// Convert a value into `T`.
 pub fn from_slice<T>(s: &'_ [u8]) -> Result<T, Error>
 where
-    T: Deserialize<'static>,
+    T: DeserializeOwned,
 {
     let s = std::str::from_utf8(s).map_err(Error::custom)?;
     from_str(s)
@@ -87,7 +87,7 @@ where
 /// Convert a document into `T`.
 pub fn from_document<T>(d: crate::Document) -> Result<T, Error>
 where
-    T: Deserialize<'static>,
+    T: DeserializeOwned,
 {
     let deserializer = Deserializer::new(d);
     T::deserialize(deserializer)
@@ -96,7 +96,7 @@ where
 /// Convert an item into `T`.
 pub fn from_item<T>(d: crate::Item) -> Result<T, Error>
 where
-    T: Deserialize<'static>,
+    T: DeserializeOwned,
 {
     T::deserialize(d)
 }

--- a/src/easy/value.rs
+++ b/src/easy/value.rs
@@ -64,7 +64,7 @@ impl Value {
     /// primitive type.
     pub fn try_into<T>(self) -> Result<T, crate::TomlError>
     where
-        T: serde::de::Deserialize<'static>,
+        T: serde::de::DeserializeOwned,
     {
         let item = super::ser::to_item(&self)?;
         let value = super::de::from_item(item)?;


### PR DESCRIPTION
From serde.rs

> Note that `<T> where T: Deserialize<'static>` is never what you want.
> Also `Deserialize<'de> + 'static` is never what you want. Generally
> writing `'static` anywhere near `Deserialize` is a sign of being on the
> wrong track. Use one of the above bounds instead.

Found by jonhoo when trying out `toml_edit`