### PR TITLE
Add `Table::sort_by` to support custom sorting

### DIFF
--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -97,32 +97,26 @@ impl InlineTable {
     ///
     /// The comparison function receives two key and value pairs to compare (you can sort by keys or
     /// values or their combination as needed).
-    pub fn sort_values_by<F>(&mut self, compare: F)
+    pub fn sort_values_by<F>(&mut self, mut compare: F)
     where
-        F: Fn(&Key, &Item, &Key, &Item) -> std::cmp::Ordering,
+        F: FnMut(&Key, &Item, &Key, &Item) -> std::cmp::Ordering,
     {
-        let cmp = &compare;
+        self.sort_values_by_internal(&mut compare);
+    }
+
+    fn sort_values_by_internal<F>(&mut self, compare: &mut F)
+    where
+        F: FnMut(&Key, &Item, &Key, &Item) -> std::cmp::Ordering,
+    {
         let modified_cmp = |_: &InternalString,
                             val1: &TableKeyValue,
                             _: &InternalString,
                             val2: &TableKeyValue|
          -> std::cmp::Ordering {
-            cmp(&val1.key, &val1.value, &val2.key, &val2.value)
+            compare(&val1.key, &val1.value, &val2.key, &val2.value)
         };
 
-        self.sort_values_by_internal(&modified_cmp);
-    }
-
-    fn sort_values_by_internal<F>(&mut self, compare: &F)
-    where
-        F: Fn(
-            &InternalString,
-            &TableKeyValue,
-            &InternalString,
-            &TableKeyValue,
-        ) -> std::cmp::Ordering,
-    {
-        self.items.sort_by(compare);
+        self.items.sort_by(modified_cmp);
         for kv in self.items.values_mut() {
             match &mut kv.value {
                 Item::Value(Value::InlineTable(table)) if table.is_dotted() => {

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -93,6 +93,46 @@ impl InlineTable {
         }
     }
 
+    /// Sort Key/Value Pairs of the table using the using the comparison function `compare`.
+    ///
+    /// The comparison function receives two key and value pairs to compare (you can sort by keys or
+    /// values or their combination as needed).
+    pub fn sort_by<F>(&mut self, compare: F)
+    where
+        F: Fn(&Key, &Item, &Key, &Item) -> std::cmp::Ordering,
+    {
+        let cmp = &compare;
+        let modified_cmp = |_: &InternalString,
+                            val1: &TableKeyValue,
+                            _: &InternalString,
+                            val2: &TableKeyValue|
+         -> std::cmp::Ordering {
+            cmp(&val1.key, &val1.value, &val2.key, &val2.value)
+        };
+
+        self.sort_by_internal(&modified_cmp);
+    }
+
+    fn sort_by_internal<F>(&mut self, compare: &F)
+    where
+        F: Fn(
+            &InternalString,
+            &TableKeyValue,
+            &InternalString,
+            &TableKeyValue,
+        ) -> std::cmp::Ordering,
+    {
+        self.items.sort_by(compare);
+        for kv in self.items.values_mut() {
+            match &mut kv.value {
+                Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
+                    table.sort_by_internal(compare);
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Change this table's dotted status
     pub fn set_dotted(&mut self, yes: bool) {
         self.dotted = yes;

--- a/src/inline_table.rs
+++ b/src/inline_table.rs
@@ -97,7 +97,7 @@ impl InlineTable {
     ///
     /// The comparison function receives two key and value pairs to compare (you can sort by keys or
     /// values or their combination as needed).
-    pub fn sort_by<F>(&mut self, compare: F)
+    pub fn sort_values_by<F>(&mut self, compare: F)
     where
         F: Fn(&Key, &Item, &Key, &Item) -> std::cmp::Ordering,
     {
@@ -110,10 +110,10 @@ impl InlineTable {
             cmp(&val1.key, &val1.value, &val2.key, &val2.value)
         };
 
-        self.sort_by_internal(&modified_cmp);
+        self.sort_values_by_internal(&modified_cmp);
     }
 
-    fn sort_by_internal<F>(&mut self, compare: &F)
+    fn sort_values_by_internal<F>(&mut self, compare: &F)
     where
         F: Fn(
             &InternalString,
@@ -126,7 +126,7 @@ impl InlineTable {
         for kv in self.items.values_mut() {
             match &mut kv.value {
                 Item::Value(Value::InlineTable(table)) if table.is_dotted() => {
-                    table.sort_by_internal(compare);
+                    table.sort_values_by_internal(compare);
                 }
                 _ => {}
             }

--- a/src/table.rs
+++ b/src/table.rs
@@ -121,7 +121,7 @@ impl Table {
     ///
     /// The comparison function receives two key and value pairs to compare (you can sort by keys or
     /// values or their combination as needed).
-    pub fn sort_by<F>(&mut self, compare: F)
+    pub fn sort_values_by<F>(&mut self, compare: F)
     where
         F: Fn(&Key, &Item, &Key, &Item) -> std::cmp::Ordering,
     {
@@ -134,10 +134,10 @@ impl Table {
             cmp(&val1.key, &val1.value, &val2.key, &val2.value)
         };
 
-        self.sort_by_internal(&modified_cmp);
+        self.sort_values_by_internal(&modified_cmp);
     }
 
-    fn sort_by_internal<F>(&mut self, compare: &F)
+    fn sort_values_by_internal<F>(&mut self, compare: &F)
     where
         F: Fn(
             &InternalString,
@@ -150,7 +150,7 @@ impl Table {
         for kv in self.items.values_mut() {
             match &mut kv.value {
                 Item::Table(table) if table.is_dotted() => {
-                    table.sort_by_internal(compare);
+                    table.sort_values_by_internal(compare);
                 }
                 _ => {}
             }

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -460,7 +460,7 @@ fn test_sort_values() {
 }
 
 #[test]
-fn test_sort_by() {
+fn test_sort_values_by() {
     given(
         r#"
         [a.z]
@@ -478,7 +478,7 @@ fn test_sort_by() {
         let a = as_table!(a);
         // Sort by the representation, not the value. So "\"c\"" sorts before "a" because '"' sorts
         // before 'a'.
-        a.sort_by(|k1, _, k2, _| k1.to_repr().as_raw().cmp(k2.to_repr().as_raw()));
+        a.sort_values_by(|k1, _, k2, _| k1.to_repr().as_raw().cmp(k2.to_repr().as_raw()));
     })
     .produces_display(
         r#"

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -460,6 +460,42 @@ fn test_sort_values() {
 }
 
 #[test]
+fn test_sort_by() {
+    given(
+        r#"
+        [a.z]
+
+        [a]
+        # this comment is attached to b
+        b = 2 # as well as this
+        a = 1
+        "c" = 3
+
+        [a.y]"#,
+    )
+    .running(|root| {
+        let a = root.get_mut("a").unwrap();
+        let a = as_table!(a);
+        // Sort by the representation, not the value. So "\"c\"" sorts before "a" because '"' sorts
+        // before 'a'.
+        a.sort_by(|k1, _, k2, _| k1.to_repr().as_raw().cmp(k2.to_repr().as_raw()));
+    })
+    .produces_display(
+        r#"
+        [a.z]
+
+        [a]
+        "c" = 3
+        a = 1
+        # this comment is attached to b
+        b = 2 # as well as this
+
+        [a.y]
+"#,
+    );
+}
+
+#[test]
 fn test_set_position() {
     given(
         r#"


### PR DESCRIPTION
Also add `InlineTable::sort_by` for parity.

We have large TOML documents that have been sorted using a
non-TOML-aware sorter (for example, highlighting a block of code and
using VSCode to sort a table). This ends up sorting quoted keys ahead of
non-quoted keys.

```toml
[table]
"a key" = 1
"b key" = "Example"
"c key" = false
akey = 2
bkey = "Another example"
ckey = true
```

When adding a new entry to a table, we would like to keep that sort. The
current `Table::sort_values` function intelligently sorts by the value
of the key.

```toml
[table]
"a key" = 1
akey = 2
"b key" = "Example"
bkey = "Another example"
"c key" = false
ckey = true
```

To allow controlling the sort order, add `Table::sort_by` (which is a
thin wrapper over `IndexMap::sort_by`). This allows us to do the
following to preserve non-intelligent sorting.

```rust
table.insert("another", Item::Value("Another".into()));
table.sort_by(|k1, _, k2, _| k1.to_repr().as_raw().cmp(k2.to_repr().as_raw());
```

And get the output that we want.

```toml
[table]
"a key" = 1
"b key" = "Example"
"c key" = false
akey = 2
another = "Another"
bkey = "Another example"
ckey = true
```