### PR TITLE
test: Fully test error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ kstring = { version = "1", features = ["max_inline"] }
 serde_json = "1.0.44"
 pretty_assertions = "1.0.0"
 toml-test-harness = "0.3"
+fs_snapshot = "0.1.1"
 criterion = "0.3"
 toml = "0.5"
 
@@ -64,6 +65,10 @@ harness = false
 
 [[test]]
 name = "easy_encoder_compliance"
+harness = false
+
+[[test]]
+name = "test_invalid"
 harness = false
 
 [[bench]]

--- a/tests/fixtures/invalid/datetime-malformed-no-leads.stderr
+++ b/tests/fixtures/invalid/datetime-malformed-no-leads.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 18
+  |
+1 | no-leads = 1987-7-05T17:45:00Z
+  |                  ^
+expected 1 more elements
+While parsing a Date-Time

--- a/tests/fixtures/invalid/datetime-malformed-no-secs.stderr
+++ b/tests/fixtures/invalid/datetime-malformed-no-secs.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 27
+  |
+1 | no-secs = 1987-07-05T17:45Z
+  |                           ^
+Unexpected `Z`
+Expected `:`
+While parsing a Date-Time

--- a/tests/fixtures/invalid/datetime-malformed-no-t.stderr
+++ b/tests/fixtures/invalid/datetime-malformed-no-t.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 18
+  |
+1 | no-t = 1987-07-0517:45:00Z
+  |                  ^
+Unexpected `1`
+Expected `#`

--- a/tests/fixtures/invalid/datetime-malformed-with-milli.stderr
+++ b/tests/fixtures/invalid/datetime-malformed-with-milli.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 23
+  |
+1 | with-milli = 1987-07-5T17:45:00.12Z
+  |                       ^
+expected 1 more elements
+While parsing a Date-Time

--- a/tests/fixtures/invalid/duplicate-key-dotted-into-std.stderr
+++ b/tests/fixtures/invalid/duplicate-key-dotted-into-std.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 5, column 1
+  |
+5 | apple.color = "red"
+  | ^
+Duplicate key `color` in `<unknown>` table
+

--- a/tests/fixtures/invalid/duplicate-key-std-into-dotted.stderr
+++ b/tests/fixtures/invalid/duplicate-key-std-into-dotted.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 6, column 1
+  |
+6 | size = "small"
+  | ^
+Duplicate key `size` in `<unknown>` table
+

--- a/tests/fixtures/invalid/duplicate-key-table.stderr
+++ b/tests/fixtures/invalid/duplicate-key-table.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 4, column 1
+  |
+4 | [fruit.type]
+  | ^
+Duplicate key `type` in `[fruit]` table
+
+While parsing a Table Header

--- a/tests/fixtures/invalid/duplicate-keys.stderr
+++ b/tests/fixtures/invalid/duplicate-keys.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 2, column 1
+  |
+2 | dupe = true
+  | ^
+Duplicate key `dupe` in `<unknown>` table
+

--- a/tests/fixtures/invalid/duplicate-tables.stderr
+++ b/tests/fixtures/invalid/duplicate-tables.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 2, column 1
+  |
+2 | [a]
+  | ^
+Duplicate key `a` in `[]` table
+
+While parsing a Table Header

--- a/tests/fixtures/invalid/empty-implicit-table.stderr
+++ b/tests/fixtures/invalid/empty-implicit-table.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 10
+  |
+1 | [naughty..naughty]
+  |          ^
+Unexpected `.`
+While parsing a Table Header

--- a/tests/fixtures/invalid/empty-table.stderr
+++ b/tests/fixtures/invalid/empty-table.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 2
+  |
+1 | []
+  |  ^
+Unexpected `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/float-leading-zero-neg.stderr
+++ b/tests/fixtures/invalid/float-leading-zero-neg.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 18
+  |
+1 | leading-zero = -03.14
+  |                  ^
+Unexpected `3`
+Expected `#`

--- a/tests/fixtures/invalid/float-leading-zero-pos.stderr
+++ b/tests/fixtures/invalid/float-leading-zero-pos.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 18
+  |
+1 | leading-zero = +03.14
+  |                  ^
+Unexpected `3`
+Expected `#`

--- a/tests/fixtures/invalid/float-leading-zero.stderr
+++ b/tests/fixtures/invalid/float-leading-zero.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 17
+  |
+1 | leading-zero = 03.14
+  |                 ^
+Unexpected `3`
+Expected `#`

--- a/tests/fixtures/invalid/float-no-leading-zero.stderr
+++ b/tests/fixtures/invalid/float-no-leading-zero.stderr
@@ -1,0 +1,15 @@
+TOML parse error at line 1, column 10
+  |
+1 | answer = .12345
+  |          ^
+Unexpected `.`
+Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
+expected 4 more elements
+expected 2 more elements
+While parsing a Time
+While parsing a hexadecimal Integer
+While parsing a octal Integer
+While parsing a binary Integer
+While parsing an Integer
+While parsing a Date-Time
+While parsing a Float

--- a/tests/fixtures/invalid/float-no-trailing-digits.stderr
+++ b/tests/fixtures/invalid/float-no-trailing-digits.stderr
@@ -1,0 +1,8 @@
+TOML parse error at line 1, column 12
+  |
+1 | answer = 1.
+  |            ^
+Unexpected `
+`
+Expected `digit`
+While parsing a Float

--- a/tests/fixtures/invalid/float-underscore-after-point.stderr
+++ b/tests/fixtures/invalid/float-underscore-after-point.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 9
+  |
+1 | bad = 1._2
+  |         ^
+Unexpected `_`
+Expected `digit`
+While parsing a Float

--- a/tests/fixtures/invalid/float-underscore-after.stderr
+++ b/tests/fixtures/invalid/float-underscore-after.stderr
@@ -1,0 +1,8 @@
+TOML parse error at line 1, column 11
+  |
+1 | bad = 1.2_
+  |           ^
+Unexpected `
+`
+Expected `digit`
+While parsing a Float

--- a/tests/fixtures/invalid/float-underscore-before-point.stderr
+++ b/tests/fixtures/invalid/float-underscore-before-point.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 9
+  |
+1 | bad = 1_.2
+  |         ^
+Unexpected `.`
+Expected `digit`
+While parsing an Integer

--- a/tests/fixtures/invalid/float-underscore-before.stderr
+++ b/tests/fixtures/invalid/float-underscore-before.stderr
@@ -1,0 +1,15 @@
+TOML parse error at line 1, column 7
+  |
+1 | bad = _1.2
+  |       ^
+Unexpected `_`
+Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
+expected 4 more elements
+expected 2 more elements
+While parsing a Time
+While parsing a hexadecimal Integer
+While parsing a octal Integer
+While parsing a binary Integer
+While parsing an Integer
+While parsing a Date-Time
+While parsing a Float

--- a/tests/fixtures/invalid/integer-invalid-binary-char.stderr
+++ b/tests/fixtures/invalid/integer-invalid-binary-char.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 11
+  |
+1 | bad = 0b102
+  |           ^
+Unexpected `2`
+Expected `#`

--- a/tests/fixtures/invalid/integer-invalid-hex-char.stderr
+++ b/tests/fixtures/invalid/integer-invalid-hex-char.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 11
+  |
+1 | bad = 0x12g
+  |           ^
+Unexpected `g`
+Expected `#`

--- a/tests/fixtures/invalid/integer-invalid-octal-char.stderr
+++ b/tests/fixtures/invalid/integer-invalid-octal-char.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 11
+  |
+1 | bad = 0o758
+  |           ^
+Unexpected `8`
+Expected `#`

--- a/tests/fixtures/invalid/integer-leading-zero-neg.stderr
+++ b/tests/fixtures/invalid/integer-leading-zero-neg.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 18
+  |
+1 | leading-zero = -012
+  |                  ^
+Unexpected `1`
+Expected `#`

--- a/tests/fixtures/invalid/integer-leading-zero-pos.stderr
+++ b/tests/fixtures/invalid/integer-leading-zero-pos.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 18
+  |
+1 | leading-zero = +012
+  |                  ^
+Unexpected `1`
+Expected `#`

--- a/tests/fixtures/invalid/integer-leading-zero.stderr
+++ b/tests/fixtures/invalid/integer-leading-zero.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 17
+  |
+1 | leading-zero = 012
+  |                 ^
+Unexpected `1`
+Expected `#`

--- a/tests/fixtures/invalid/integer-underscore-after.stderr
+++ b/tests/fixtures/invalid/integer-underscore-after.stderr
@@ -1,0 +1,8 @@
+TOML parse error at line 1, column 11
+  |
+1 | bad = 123_
+  |           ^
+Unexpected `
+`
+Expected `digit`
+While parsing an Integer

--- a/tests/fixtures/invalid/integer-underscore-before.stderr
+++ b/tests/fixtures/invalid/integer-underscore-before.stderr
@@ -1,0 +1,15 @@
+TOML parse error at line 1, column 7
+  |
+1 | bad = _123
+  |       ^
+Unexpected `_`
+Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
+expected 4 more elements
+expected 2 more elements
+While parsing a Time
+While parsing a hexadecimal Integer
+While parsing a octal Integer
+While parsing a binary Integer
+While parsing an Integer
+While parsing a Date-Time
+While parsing a Float

--- a/tests/fixtures/invalid/integer-underscore-double.stderr
+++ b/tests/fixtures/invalid/integer-underscore-double.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 9
+  |
+1 | bad = 1__23
+  |         ^
+Unexpected `_`
+Expected `digit`
+While parsing an Integer

--- a/tests/fixtures/invalid/key-after-array.stderr
+++ b/tests/fixtures/invalid/key-after-array.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 14
+  |
+1 | [[agencies]] owner = "S Cjelli"
+  |              ^
+Unexpected `o`
+Expected `a newline` or `end of input`
+While parsing a Table Header

--- a/tests/fixtures/invalid/key-after-table.stderr
+++ b/tests/fixtures/invalid/key-after-table.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 9
+  |
+1 | [error] this = "should not be here"
+  |         ^
+Unexpected `t`
+Expected `a newline` or `end of input`
+While parsing a Table Header

--- a/tests/fixtures/invalid/key-empty.stderr
+++ b/tests/fixtures/invalid/key-empty.stderr
@@ -1,0 +1,5 @@
+TOML parse error at line 1, column 2
+  |
+1 |  = 1
+  |  ^
+Unexpected `=`

--- a/tests/fixtures/invalid/key-hash.stderr
+++ b/tests/fixtures/invalid/key-hash.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 2
+  |
+1 | a# = 1
+  |  ^
+Unexpected `#`
+Expected `.` or `=`

--- a/tests/fixtures/invalid/key-newline.stderr
+++ b/tests/fixtures/invalid/key-newline.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 2
+  |
+1 | a
+  |  ^
+Unexpected `
+`
+Expected `.` or `=`

--- a/tests/fixtures/invalid/key-no-eol.stderr
+++ b/tests/fixtures/invalid/key-no-eol.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 7
+  |
+1 | a = 1 b = 2
+  |       ^
+Unexpected `b`
+Expected `a newline` or `end of input`

--- a/tests/fixtures/invalid/key-open-bracket.stderr
+++ b/tests/fixtures/invalid/key-open-bracket.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 6
+  |
+1 | [abc = 1
+  |      ^
+Unexpected `=`
+Expected `.` or `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/key-single-open-bracket.stderr
+++ b/tests/fixtures/invalid/key-single-open-bracket.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 2
+  |
+1 | [
+  |  ^
+Unexpected `end of input`
+While parsing a Table Header

--- a/tests/fixtures/invalid/key-space.stderr
+++ b/tests/fixtures/invalid/key-space.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 3
+  |
+1 | a b = 1
+  |   ^
+Unexpected `b`
+Expected `.` or `=`

--- a/tests/fixtures/invalid/key-start-bracket.stderr
+++ b/tests/fixtures/invalid/key-start-bracket.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 2, column 6
+  |
+2 | [xyz = 5
+  |      ^
+Unexpected `=`
+Expected `.` or `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/key-two-equals.stderr
+++ b/tests/fixtures/invalid/key-two-equals.stderr
@@ -1,0 +1,15 @@
+TOML parse error at line 1, column 6
+  |
+1 | key= = 1
+  |      ^
+Unexpected `=`
+Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
+expected 4 more elements
+expected 2 more elements
+While parsing a Time
+While parsing a hexadecimal Integer
+While parsing a octal Integer
+While parsing a binary Integer
+While parsing an Integer
+While parsing a Date-Time
+While parsing a Float

--- a/tests/fixtures/invalid/llbrace.stderr
+++ b/tests/fixtures/invalid/llbrace.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 3
+  |
+1 | [ [table]]
+  |   ^
+Unexpected `[`
+Unexpected ` `
+While parsing a Table Header

--- a/tests/fixtures/invalid/rrbrace.stderr
+++ b/tests/fixtures/invalid/rrbrace.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 8
+  |
+1 | [[table] ]
+  |        ^
+Unexpected `]`
+Expected `.` or `]]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/string-bad-byte-escape.stderr
+++ b/tests/fixtures/invalid/string-bad-byte-escape.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 13
+  |
+1 | naughty = "\xAg"
+  |             ^
+Unexpected `x`
+While parsing escape sequence
+While parsing a Basic String

--- a/tests/fixtures/invalid/string-bad-escape.stderr
+++ b/tests/fixtures/invalid/string-bad-escape.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 42
+  |
+1 | invalid-escape = "This string has a bad \a escape character."
+  |                                          ^
+Unexpected `a`
+While parsing escape sequence
+While parsing a Basic String

--- a/tests/fixtures/invalid/string-bad-surrogate.stderr
+++ b/tests/fixtures/invalid/string-bad-surrogate.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 15
+  |
+1 | notgood = "a\uDCFF"
+  |               ^
+Invalid hex escape code: dcff 
+
+While parsing a Basic String

--- a/tests/fixtures/invalid/string-bad-uni-esc.stderr
+++ b/tests/fixtures/invalid/string-bad-uni-esc.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 14
+  |
+1 | str = "val\ue"
+  |              ^
+expected 3 more elements
+While parsing a Basic String

--- a/tests/fixtures/invalid/string-byte-escapes.stderr
+++ b/tests/fixtures/invalid/string-byte-escapes.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 12
+  |
+1 | answer = "\x33"
+  |            ^
+Unexpected `x`
+While parsing escape sequence
+While parsing a Basic String

--- a/tests/fixtures/invalid/string-no-close.stderr
+++ b/tests/fixtures/invalid/string-no-close.stderr
@@ -1,0 +1,8 @@
+TOML parse error at line 1, column 42
+  |
+1 | no-ending-quote = "One time, at band camp
+  |                                          ^
+Unexpected `
+`
+Expected `"`
+While parsing a Basic String

--- a/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 8
+  |
+1 | value=trust
+  |        ^
+Unexpected `r`
+Expected `rue`

--- a/tests/fixtures/invalid/string-no-quotes-constant-like.toml
+++ b/tests/fixtures/invalid/string-no-quotes-constant-like.toml
@@ -1,0 +1,1 @@
+value=trust

--- a/tests/fixtures/invalid/string-no-quotes-in-array.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-array.stderr
@@ -1,0 +1,15 @@
+TOML parse error at line 1, column 9
+  |
+1 | value = ZZZ
+  |         ^
+Unexpected `Z`
+Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
+expected 4 more elements
+expected 2 more elements
+While parsing a Time
+While parsing a hexadecimal Integer
+While parsing a octal Integer
+While parsing a binary Integer
+While parsing an Integer
+While parsing a Date-Time
+While parsing a Float

--- a/tests/fixtures/invalid/string-no-quotes-in-array.toml
+++ b/tests/fixtures/invalid/string-no-quotes-in-array.toml
@@ -1,0 +1,1 @@
+value = ZZZ

--- a/tests/fixtures/invalid/string-no-quotes-in-inline-table.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-inline-table.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 10
+  |
+1 | value = [ZZZ]
+  |          ^
+Unexpected `Z`
+Expected `a newline` or `#`

--- a/tests/fixtures/invalid/string-no-quotes-in-inline-table.toml
+++ b/tests/fixtures/invalid/string-no-quotes-in-inline-table.toml
@@ -1,0 +1,1 @@
+value = [ZZZ]

--- a/tests/fixtures/invalid/string-no-quotes-in-table.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-table.stderr
@@ -1,0 +1,15 @@
+TOML parse error at line 1, column 14
+  |
+1 | value={key = ZZZ}
+  |              ^
+Unexpected `Z`
+Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
+expected 4 more elements
+expected 2 more elements
+While parsing a Time
+While parsing a hexadecimal Integer
+While parsing a octal Integer
+While parsing a binary Integer
+While parsing an Integer
+While parsing a Date-Time
+While parsing a Float

--- a/tests/fixtures/invalid/string-no-quotes-in-table.toml
+++ b/tests/fixtures/invalid/string-no-quotes-in-table.toml
@@ -1,0 +1,1 @@
+value={key = ZZZ}

--- a/tests/fixtures/invalid/string-no-quotes-number-like.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-number-like.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 10
+  |
+1 | value=123hello
+  |          ^
+Unexpected `h`
+Expected `#`

--- a/tests/fixtures/invalid/string-no-quotes-number-like.toml
+++ b/tests/fixtures/invalid/string-no-quotes-number-like.toml
@@ -1,0 +1,1 @@
+value=123hello

--- a/tests/fixtures/invalid/table-array-implicit.stderr
+++ b/tests/fixtures/invalid/table-array-implicit.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 13, column 1
+   |
+13 | [[albums]]
+   | ^
+Duplicate key `albums` in `[]` table
+
+While parsing a Table Header

--- a/tests/fixtures/invalid/table-array-malformed-bracket.stderr
+++ b/tests/fixtures/invalid/table-array-malformed-bracket.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 9
+  |
+1 | [[albums]
+  |         ^
+Unexpected `]`
+Expected `.` or `]]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/table-array-malformed-empty.stderr
+++ b/tests/fixtures/invalid/table-array-malformed-empty.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 3
+  |
+1 | [[]]
+  |   ^
+Unexpected `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/table-empty.stderr
+++ b/tests/fixtures/invalid/table-empty.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 2
+  |
+1 | []
+  |  ^
+Unexpected `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/table-nested-brackets-close.stderr
+++ b/tests/fixtures/invalid/table-nested-brackets-close.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 4
+  |
+1 | [a]b]
+  |    ^
+Unexpected `b`
+Expected `#`
+While parsing a Table Header

--- a/tests/fixtures/invalid/table-nested-brackets-open.stderr
+++ b/tests/fixtures/invalid/table-nested-brackets-open.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 3
+  |
+1 | [a[b]
+  |   ^
+Unexpected `[`
+Expected `.` or `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/table-whitespace.stderr
+++ b/tests/fixtures/invalid/table-whitespace.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 10
+  |
+1 | [invalid key]
+  |          ^
+Unexpected `k`
+Expected `.` or `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/table-with-pound.stderr
+++ b/tests/fixtures/invalid/table-with-pound.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 5
+  |
+1 | [key#group]
+  |     ^
+Unexpected `#`
+Expected `.` or `]`
+While parsing a Table Header

--- a/tests/fixtures/invalid/text-after-array-entries.stderr
+++ b/tests/fixtures/invalid/text-after-array-entries.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 2, column 46
+  |
+2 |   "Is there life after an array separator?", No
+  |                                              ^
+Unexpected `N`
+Expected `]`

--- a/tests/fixtures/invalid/text-after-integer.stderr
+++ b/tests/fixtures/invalid/text-after-integer.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 13
+  |
+1 | answer = 42 the ultimate answer?
+  |             ^
+Unexpected `t`
+Expected `a newline` or `end of input`

--- a/tests/fixtures/invalid/text-after-string.stderr
+++ b/tests/fixtures/invalid/text-after-string.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 1, column 41
+  |
+1 | string = "Is there life after strings?" No.
+  |                                         ^
+Unexpected `N`
+Expected `a newline` or `end of input`

--- a/tests/fixtures/invalid/text-after-table.stderr
+++ b/tests/fixtures/invalid/text-after-table.stderr
@@ -1,0 +1,7 @@
+TOML parse error at line 1, column 9
+  |
+1 | [error] this shouldn't be here
+  |         ^
+Unexpected `t`
+Expected `a newline` or `end of input`
+While parsing a Table Header

--- a/tests/fixtures/invalid/text-before-array-separator.stderr
+++ b/tests/fixtures/invalid/text-before-array-separator.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 2, column 46
+  |
+2 |   "Is there life before an array separator?" No,
+  |                                              ^
+Unexpected `N`
+Expected `]`

--- a/tests/fixtures/invalid/text-in-array.stderr
+++ b/tests/fixtures/invalid/text-in-array.stderr
@@ -1,0 +1,6 @@
+TOML parse error at line 3, column 3
+  |
+3 |   I don't belong,
+  |   ^
+Unexpected `I`
+Expected `]`

--- a/tests/test_invalid.rs
+++ b/tests/test_invalid.rs
@@ -1,385 +1,50 @@
 use toml_edit::Document;
 
-#[track_caller]
-fn run_contains(toml: &str, msg: &str) {
-    let doc = toml.parse::<Document>();
-
-    let err = match doc {
-        Err(e) => e.to_string(),
-        _ => unreachable!("must fail"),
+fn main() {
+    let action = std::env::var("INVALID_TOML");
+    let action = action.as_deref().unwrap_or("verify");
+    let action = match action {
+        "overwrite" => Action::Overwrite,
+        "ignore" => Action::Ignore,
+        "verify" => Action::Verify,
+        _ => panic!(
+            "Unrecognized action {}, expected `overwrite`, `ignore`, or `verify`",
+            action
+        ),
     };
-    dbg!(msg);
-    dbg!(&err);
-    assert!(err.contains(msg));
+
+    fs_snapshot::Harness::new(
+        "tests/fixtures/invalid",
+        move |input_path| {
+            let name = input_path.file_name().unwrap().to_str().unwrap().to_owned();
+            let expected = input_path.with_extension("stderr");
+            fs_snapshot::Test {
+                name,
+                kind: "".into(),
+                is_ignored: action == Action::Ignore,
+                is_bench: false,
+                data: fs_snapshot::Case {
+                    fixture: input_path,
+                    expected,
+                },
+            }
+        },
+        move |input_path| {
+            let raw = std::fs::read_to_string(input_path).map_err(|e| e.to_string())?;
+            match raw.parse::<Document>() {
+                Ok(_) => Err("Parsing unexpectedly succeeded".to_owned()),
+                Err(err) => Ok(err.to_string()),
+            }
+        },
+    )
+    .select(["*.toml"])
+    .overwrite(action == Action::Overwrite)
+    .test()
 }
 
-#[track_caller]
-fn run_exact(toml: &str, msg: &str) {
-    let doc = toml.parse::<Document>();
-
-    let err = match doc {
-        Err(e) => e.to_string(),
-        _ => unreachable!("must fail"),
-    };
-    assert_eq!(err, msg);
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Action {
+    Overwrite,
+    Verify,
+    Ignore,
 }
-
-macro_rules! t_exact(
-    ($name:ident, $toml:expr, $msg:expr, ) => (
-        #[test]
-        fn $name() {
-            run_exact($toml, $msg);
-        }
-    )
-);
-
-macro_rules! t_file_contains(
-    ($name:ident, $toml:expr, $msg:expr, ) => (
-        #[test]
-        fn $name() {
-            run_contains(include_str!($toml), $msg);
-        }
-    )
-);
-
-t_file_contains!(
-    test_datetime_malformed_no_leads,
-    "fixtures/invalid/datetime-malformed-no-leads.toml",
-    "While parsing a Date-Time",
-);
-t_file_contains!(
-    test_datetime_malformed_no_secs,
-    "fixtures/invalid/datetime-malformed-no-secs.toml",
-    "While parsing a Date-Time",
-);
-t_file_contains!(
-    test_datetime_malformed_no_t,
-    "fixtures/invalid/datetime-malformed-no-t.toml",
-    "",
-);
-t_file_contains!(
-    test_datetime_malformed_with_milli,
-    "fixtures/invalid/datetime-malformed-with-milli.toml",
-    "While parsing a Date-Time",
-);
-t_file_contains!(
-    test_duplicate_keys,
-    "fixtures/invalid/duplicate-keys.toml",
-    "Duplicate key",
-);
-t_file_contains!(
-    test_duplicate_key_table,
-    "fixtures/invalid/duplicate-key-table.toml",
-    "Duplicate key",
-);
-t_file_contains!(
-    test_duplicate_tables,
-    "fixtures/invalid/duplicate-tables.toml",
-    "Duplicate key",
-);
-t_file_contains!(
-    test_duplicate_key_std_into_dotted,
-    "fixtures/invalid/duplicate-key-std-into-dotted.toml",
-    "Duplicate key",
-);
-t_file_contains!(
-    test_duplicate_key_dotted_into_std,
-    "fixtures/invalid/duplicate-key-dotted-into-std.toml",
-    "Duplicate key",
-);
-t_file_contains!(
-    test_empty_implicit_table,
-    "fixtures/invalid/empty-implicit-table.toml",
-    "While parsing a Table Header",
-);
-t_file_contains!(
-    test_empty_table,
-    "fixtures/invalid/empty-table.toml",
-    "While parsing a Table Header",
-);
-t_file_contains!(
-    test_float_leading_zero_neg,
-    "fixtures/invalid/float-leading-zero-neg.toml",
-    "Unexpected `3`",
-);
-t_file_contains!(
-    test_float_leading_zero_pos,
-    "fixtures/invalid/float-leading-zero-pos.toml",
-    "Unexpected `3`",
-);
-t_file_contains!(
-    test_float_leading_zero,
-    "fixtures/invalid/float-leading-zero.toml",
-    "Unexpected `3`",
-);
-t_file_contains!(
-    test_float_no_leading_zero,
-    "fixtures/invalid/float-no-leading-zero.toml",
-    "Unexpected `.`",
-);
-t_file_contains!(
-    test_float_no_trailing_digits,
-    "fixtures/invalid/float-no-trailing-digits.toml",
-    "While parsing a Float",
-);
-t_file_contains!(
-    test_float_underscore_after_point,
-    "fixtures/invalid/float-underscore-after-point.toml",
-    "While parsing a Float",
-);
-t_file_contains!(
-    test_float_underscore_after,
-    "fixtures/invalid/float-underscore-after.toml",
-    "column 11",
-);
-t_file_contains!(
-    test_float_underscore_before_point,
-    "fixtures/invalid/float-underscore-before-point.toml",
-    "column 9",
-);
-t_file_contains!(
-    test_float_underscore_before,
-    "fixtures/invalid/float-underscore-before.toml",
-    "column 7",
-);
-t_file_contains!(
-    test_integer_leading_zero_neg,
-    "fixtures/invalid/integer-leading-zero-neg.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_leading_zero_pos,
-    "fixtures/invalid/integer-leading-zero-pos.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_leading_zero,
-    "fixtures/invalid/integer-leading-zero.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_underscore_after,
-    "fixtures/invalid/integer-underscore-after.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_underscore_before,
-    "fixtures/invalid/integer-underscore-before.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_underscore_double,
-    "fixtures/invalid/integer-underscore-double.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_invalid_hex_char,
-    "fixtures/invalid/integer-invalid-hex-char.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_invalid_octal_char,
-    "fixtures/invalid/integer-invalid-octal-char.toml",
-    "",
-);
-t_file_contains!(
-    test_integer_invalid_binary_char,
-    "fixtures/invalid/integer-invalid-binary-char.toml",
-    "",
-);
-t_file_contains!(
-    test_key_after_array,
-    "fixtures/invalid/key-after-array.toml",
-    "",
-);
-t_file_contains!(
-    test_key_after_table,
-    "fixtures/invalid/key-after-table.toml",
-    "",
-);
-t_file_contains!(test_key_empty, "fixtures/invalid/key-empty.toml", "",);
-t_file_contains!(test_key_hash, "fixtures/invalid/key-hash.toml", "",);
-t_file_contains!(test_key_newline, "fixtures/invalid/key-newline.toml", "",);
-t_file_contains!(test_key_no_eol, "fixtures/invalid/key-no-eol.toml", "",);
-t_file_contains!(
-    test_key_open_bracket,
-    "fixtures/invalid/key-open-bracket.toml",
-    "",
-);
-t_file_contains!(
-    test_key_single_open_bracket,
-    "fixtures/invalid/key-single-open-bracket.toml",
-    "",
-);
-t_file_contains!(test_key_space, "fixtures/invalid/key-space.toml", "",);
-t_file_contains!(
-    test_key_start_bracket,
-    "fixtures/invalid/key-start-bracket.toml",
-    "",
-);
-t_file_contains!(
-    test_key_two_equals,
-    "fixtures/invalid/key-two-equals.toml",
-    "",
-);
-t_file_contains!(test_llbrace, "fixtures/invalid/llbrace.toml", "",);
-t_file_contains!(test_rrbrace, "fixtures/invalid/rrbrace.toml", "",);
-t_file_contains!(
-    test_string_bad_byte_escape,
-    "fixtures/invalid/string-bad-byte-escape.toml",
-    "",
-);
-t_file_contains!(
-    test_string_bad_escape,
-    "fixtures/invalid/string-bad-escape.toml",
-    "",
-);
-t_file_contains!(
-    test_string_bad_surrogate,
-    "fixtures/invalid/string-bad-surrogate.toml",
-    "",
-);
-t_file_contains!(
-    test_string_bad_uni_esc,
-    "fixtures/invalid/string-bad-uni-esc.toml",
-    "",
-);
-t_file_contains!(
-    test_string_byte_escapes,
-    "fixtures/invalid/string-byte-escapes.toml",
-    "",
-);
-t_file_contains!(
-    test_string_no_close,
-    "fixtures/invalid/string-no-close.toml",
-    "",
-);
-t_file_contains!(
-    test_table_array_implicit,
-    "fixtures/invalid/table-array-implicit.toml",
-    "",
-);
-t_file_contains!(
-    test_table_array_malformed_bracket,
-    "fixtures/invalid/table-array-malformed-bracket.toml",
-    "",
-);
-t_file_contains!(
-    test_table_array_malformed_empty,
-    "fixtures/invalid/table-array-malformed-empty.toml",
-    "",
-);
-t_file_contains!(test_table_empty, "fixtures/invalid/table-empty.toml", "",);
-t_file_contains!(
-    test_table_nested_brackets_close,
-    "fixtures/invalid/table-nested-brackets-close.toml",
-    "",
-);
-t_file_contains!(
-    test_table_nested_brackets_open,
-    "fixtures/invalid/table-nested-brackets-open.toml",
-    "",
-);
-t_file_contains!(
-    test_table_whitespace,
-    "fixtures/invalid/table-whitespace.toml",
-    "",
-);
-t_file_contains!(
-    test_table_with_pound,
-    "fixtures/invalid/table-with-pound.toml",
-    "",
-);
-t_file_contains!(
-    test_text_after_array_entries,
-    "fixtures/invalid/text-after-array-entries.toml",
-    "",
-);
-t_file_contains!(
-    test_text_after_integer,
-    "fixtures/invalid/text-after-integer.toml",
-    "",
-);
-t_file_contains!(
-    test_text_after_string,
-    "fixtures/invalid/text-after-string.toml",
-    "",
-);
-t_file_contains!(
-    test_text_after_table,
-    "fixtures/invalid/text-after-table.toml",
-    "",
-);
-t_file_contains!(
-    test_text_before_array_separator,
-    "fixtures/invalid/text-before-array-separator.toml",
-    "",
-);
-t_file_contains!(
-    test_text_in_array,
-    "fixtures/invalid/text-in-array.toml",
-    "",
-);
-
-t_exact!(
-    test_quote_suggestion_in_key_value_pair,
-    "value= ZZZ",
-    "TOML parse error at line 1, column 8
-  |
-1 | value= ZZZ
-  |        ^
-Unexpected `Z`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
-",
-);
-t_exact!(
-    test_quote_suggestion_in_array,
-    "value=[ZZZ]",
-    "TOML parse error at line 1, column 8
-  |
-1 | value=[ZZZ]
-  |        ^
-Unexpected `Z`
-Expected `a newline` or `#`
-",
-);
-t_exact!(
-    test_quote_suggestion_in_inline_table,
-    "value={key = ZZZ}",
-    "TOML parse error at line 1, column 14
-  |
-1 | value={key = ZZZ}
-  |              ^
-Unexpected `Z`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
-",
-);
-t_exact!(
-    test_quote_suggestion_similar_to_constants_in_key_value_pair,
-    "value= trust",
-    "TOML parse error at line 1, column 9
-  |
-1 | value= trust
-  |         ^
-Unexpected `r`
-Expected `rue`
-",
-);


### PR DESCRIPTION
As we expand usage, the quality of our error messages will become more
important.  This uses `fs_snapshot` so we can store snapshots of errors
on the filesystem and easily update them, diff them, etc.