### PR TITLE
Help users who mistakenly use bare words

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,7 +9,7 @@ mod document;
 mod errors;
 mod inline_table;
 mod key;
-mod numbers;
+pub(crate) mod numbers;
 pub(crate) mod strings;
 mod table;
 mod trivia;

--- a/src/parser/numbers.rs
+++ b/src/parser/numbers.rs
@@ -179,11 +179,11 @@ parse!(special_float() -> f64, {
 // inf = %x69.6e.66  ; inf
 pub(crate) const INF: &[u8] = b"inf";
 parse!(inf() -> f64, {
-    range(INF).map(|_| f64::INFINITY)
+    bytes(INF).map(|_| f64::INFINITY)
 });
 
 // nan = %x6e.61.6e  ; nan
 pub(crate) const NAN: &[u8] = b"nan";
 parse!(nan() -> f64, {
-    range(NAN).map(|_| f64::NAN)
+    bytes(NAN).map(|_| f64::NAN)
 });

--- a/src/parser/numbers.rs
+++ b/src/parser/numbers.rs
@@ -15,6 +15,12 @@ parse!(boolean() -> bool, {
         (byte(FALSE[0]), range(&FALSE[1..]),),
     )).map(|p| p.0 == b't')
 });
+parse!(true_() -> bool, {
+    range(crate::parser::numbers::TRUE).map(|_| true)
+});
+parse!(false_() -> bool, {
+    range(crate::parser::numbers::FALSE).map(|_| false)
+});
 
 // ;; Integer
 

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -7,6 +7,7 @@ use crate::parser::trivia::from_utf8_unchecked;
 use crate::repr::{Formatted, Repr};
 use crate::value as v;
 use crate::Value;
+use combine::parser::range::range;
 use combine::parser::range::recognize_with_value;
 use combine::stream::RangeStream;
 use combine::*;
@@ -23,6 +24,14 @@ parse!(value() -> v::Value, {
             }),
             crate::parser::array::ARRAY_OPEN => array().map(v::Value::Array),
             crate::parser::inline_table::INLINE_TABLE_OPEN => inline_table().map(v::Value::InlineTable),
+            b'a'..=b'z' | b'A'..=b'Z' => {
+                choice((
+                    range(crate::parser::numbers::TRUE).map(|_| v::Value::from(true)),
+                    range(crate::parser::numbers::FALSE).map(|_| v::Value::from(false)),
+                    crate::parser::numbers::inf().map(v::Value::from),
+                    crate::parser::numbers::nan().map(v::Value::from),
+                ))
+            },
             // Uncommon enough not to be worth optimizing at this time
             _ => choice((
                 boolean()

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -37,14 +37,21 @@ parse!(value() -> v::Value, {
                         .map(v::Value::from),
                 ))
             },
+            b't' => {
+                crate::parser::numbers::true_().map(v::Value::from).expected("quoted string")
+            },
+            b'f' => {
+                crate::parser::numbers::false_().map(v::Value::from).expected("quoted string")
+            },
+            b'i' => {
+                crate::parser::numbers::inf().map(v::Value::from).expected("quoted string")
+            },
+            b'n' => {
+                crate::parser::numbers::nan().map(v::Value::from).expected("quoted string")
+            },
             _ => {
-                // Uncommon enough not to be worth optimizing at this time
-                choice((
-                    crate::parser::numbers::true_().map(v::Value::from),
-                    crate::parser::numbers::false_().map(v::Value::from),
-                    crate::parser::numbers::inf().map(v::Value::from),
-                    crate::parser::numbers::nan().map(v::Value::from),
-                ))
+                // Pick something random to fail, we'll override `expected` anyways
+                crate::parser::numbers::nan().map(v::Value::from).expected("quoted string")
             },
         )
     })).and_then(|(raw, value)| apply_raw(value, raw))

--- a/tests/fixtures/invalid/key-two-equals.stderr
+++ b/tests/fixtures/invalid/key-two-equals.stderr
@@ -3,13 +3,4 @@ TOML parse error at line 1, column 6
 1 | key= = 1
   |      ^
 Unexpected `=`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
+Expected `quoted string`

--- a/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
@@ -3,4 +3,4 @@ TOML parse error at line 1, column 7
 1 | value=trust
   |       ^
 Unexpected `t`
-Expected `true`, `false`, `inf` or `nan`
+Expected `quoted string`

--- a/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-constant-like.stderr
@@ -1,6 +1,6 @@
-TOML parse error at line 1, column 8
+TOML parse error at line 1, column 7
   |
 1 | value=trust
-  |        ^
-Unexpected `r`
-Expected `rue`
+  |       ^
+Unexpected `t`
+Expected `true`, `false`, `inf` or `nan`

--- a/tests/fixtures/invalid/string-no-quotes-in-array.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-array.stderr
@@ -2,14 +2,6 @@ TOML parse error at line 1, column 9
   |
 1 | value = ZZZ
   |         ^
+Unexpected `end of input`
 Unexpected `Z`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
+Expected `true`, `false`, `inf` or `nan`

--- a/tests/fixtures/invalid/string-no-quotes-in-array.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-array.stderr
@@ -1,7 +1,6 @@
-TOML parse error at line 1, column 9
+TOML parse error at line 1, column 10
   |
-1 | value = ZZZ
-  |         ^
-Unexpected `end of input`
+1 | value = [ZZZ]
+  |          ^
 Unexpected `Z`
-Expected `true`, `false`, `inf` or `nan`
+Expected `a newline` or `#`

--- a/tests/fixtures/invalid/string-no-quotes-in-array.toml
+++ b/tests/fixtures/invalid/string-no-quotes-in-array.toml
@@ -1,1 +1,1 @@
-value = ZZZ
+value = [ZZZ]

--- a/tests/fixtures/invalid/string-no-quotes-in-inline-table.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-inline-table.stderr
@@ -1,6 +1,6 @@
-TOML parse error at line 1, column 10
+TOML parse error at line 1, column 17
   |
-1 | value = [ZZZ]
-  |          ^
+1 | value = { key = ZZZ }
+  |                 ^
 Unexpected `Z`
-Expected `a newline` or `#`
+Expected `quoted string`

--- a/tests/fixtures/invalid/string-no-quotes-in-inline-table.toml
+++ b/tests/fixtures/invalid/string-no-quotes-in-inline-table.toml
@@ -1,1 +1,1 @@
-value = [ZZZ]
+value = { key = ZZZ }

--- a/tests/fixtures/invalid/string-no-quotes-in-table.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-table.stderr
@@ -1,6 +1,6 @@
-TOML parse error at line 1, column 14
+TOML parse error at line 1, column 7
   |
-1 | value={key = ZZZ}
-  |              ^
+1 | value=ZZZ
+  |       ^
 Unexpected `Z`
-Expected `true`, `false`, `inf` or `nan`
+Expected `quoted string`

--- a/tests/fixtures/invalid/string-no-quotes-in-table.stderr
+++ b/tests/fixtures/invalid/string-no-quotes-in-table.stderr
@@ -3,13 +3,4 @@ TOML parse error at line 1, column 14
 1 | value={key = ZZZ}
   |              ^
 Unexpected `Z`
-Expected `-`, `+`, `inf`, `nan`, `0x`, `0o` or `0b`
-expected 4 more elements
-expected 2 more elements
-While parsing a Time
-While parsing a hexadecimal Integer
-While parsing a octal Integer
-While parsing a binary Integer
-While parsing an Integer
-While parsing a Date-Time
-While parsing a Float
+Expected `true`, `false`, `inf` or `nan`

--- a/tests/fixtures/invalid/string-no-quotes-in-table.toml
+++ b/tests/fixtures/invalid/string-no-quotes-in-table.toml
@@ -1,1 +1,1 @@
-value={key = ZZZ}
+value=ZZZ


### PR DESCRIPTION
We are more closely matching toml-rs's behavior for error reporting so anything that doesn't look like a number or date, we'll tell the user we are expecting a quoted string.

The one caveat is that this isn't solved for arrays.  The challenge is we have to use `attempt` on the `value` parser which throws the error away and they get told to use a comment instead.