### PR TITLE
fix: Prefer implicit tables in pretty

### DIFF
--- a/src/ser/pretty.rs
+++ b/src/ser/pretty.rs
@@ -16,6 +16,7 @@ impl crate::visit_mut::VisitMut for Pretty {
 
     fn visit_table_mut(&mut self, node: &mut crate::Table) {
         node.decor_mut().clear();
+        node.set_implicit(true);
 
         crate::visit_mut::visit_table_mut(self, node);
     }


### PR DESCRIPTION
I considered making is more generally the default when converting items
but held off for now.

This is needed by cargo.