### PR TITLE
fix: toml_edit::value uses default decor

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -347,7 +347,7 @@ impl std::fmt::Display for Item {
 /// "#);
 /// ```
 pub fn value<V: Into<Value>>(v: V) -> Item {
-    Item::Value(v.into().decorated(" ", ""))
+    Item::Value(v.into())
 }
 
 /// Returns an empty table.


### PR DESCRIPTION
This will let it be used in more places