### PR TITLE
Allow using unit variants as map keys

### DIFF
--- a/src/ser/key.rs
+++ b/src/ser/key.rs
@@ -94,9 +94,9 @@ impl serde::ser::Serializer for KeySerializer {
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
     ) -> Result<InternalString, Self::Error> {
-        Err(ErrorKind::KeyNotString.into())
+        Ok(variant.into())
     }
 
     fn serialize_newtype_struct<T: ?Sized>(

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -309,6 +309,25 @@ fn parse_enum_string() {
 }
 
 #[test]
+fn map_key_unit_variants() {
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, PartialOrd, Ord)]
+    enum Sort {
+        #[serde(rename = "ascending")]
+        Asc,
+        Desc,
+    }
+
+    let mut map = BTreeMap::new();
+    map.insert(Sort::Asc, 1);
+    map.insert(Sort::Desc, 2);
+
+    equivalent! {
+        map,
+        Table(map! { ascending: Integer(1), Desc: Integer(2) }),
+    }
+}
+
+#[test]
 fn empty_arrays() {
     #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Foo {


### PR DESCRIPTION
Fixes #319 and aligns our behavior with that of serde_json.