### PR TITLE
use Entry api instead of key clone, part 2

### DIFF
--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -14,6 +14,7 @@ use combine::stream::position::{IndexPositioner, Positioner, Stream};
 use combine::stream::RangeStream;
 use combine::Parser;
 use combine::*;
+use indexmap::map::Entry;
 use std::cell::RefCell;
 use std::mem;
 use std::ops::DerefMut;
@@ -163,14 +164,17 @@ impl TomlParser {
         }
 
         let key: InternalString = kv.key.get_internal().into();
-        let old = table.items.insert(key.clone(), kv);
-        let duplicate_key = old.is_some();
-        // "Since tables cannot be defined more than once, redefining such tables using a [table] header is not allowed"
-        if duplicate_key {
-            return Err(CustomError::DuplicateKey {
-                key: key.as_str().into(),
-                table: Some(self.current_table_path.clone()),
-            });
+        match table.items.entry(key) {
+            Entry::Vacant(o) => {
+                o.insert(kv);
+            }
+            Entry::Occupied(o) => {
+                // "Since tables cannot be defined more than once, redefining such tables using a [table] header is not allowed"
+                return Err(CustomError::DuplicateKey {
+                    key: o.key().as_str().into(),
+                    table: Some(self.current_table_path.clone()),
+                });
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Somehow lost that when filled #323.

Skip key clone to speedup runtime.